### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "machine_setup"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "machine_setup"
-version = "2.2.3"
+version = "2.3.0"
 edition = "2021"
 description = "A CLI tool with TUI for automating machine configuration and setup tasks"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from 2.2.3 to 2.3.0 for release

After merge, tag `v2.3.0` to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)