### PR TITLE
feat: add depends_on, conditional tasks, retry, and TUI search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,26 @@ jobs:
             fi
           done
 
+      - name: Extract changelog
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "use_auto=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_auto=false" >> "$GITHUB_OUTPUT"
+            {
+              echo 'notes<<CHANGELOG_EOF'
+              echo "$NOTES"
+              echo 'CHANGELOG_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
           artifacts: "machine_setup-*.tar.gz,machine_setup-*.zip"
-          generateReleaseNotes: true
+          generateReleaseNotes: ${{ steps.changelog.outputs.use_auto == 'true' }}
+          body: ${{ steps.changelog.outputs.use_auto == 'false' && steps.changelog.outputs.notes || '' }}
           token: ${{ secrets.REPO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+## [2.4.0]
+
+### Added
+- `depends_on` field for DAG-based task dependency resolution
+- Conditional tasks with `only_if` and `skip_if` fields
+- Task retry on failure with `retry` field
+- TUI task filtering/search with `/` keybinding
+- JSON example configuration file (`example_config.json`)
+- CHANGELOG.md with release workflow integration
+
+## [2.3.0]
+
+### Added
+- Shell completions (`completions` subcommand)
+- Config validation (`validate` subcommand)
+- Environment variable injection prevention (env values are escaped)
+- Sub-config task indentation in TUI
+
+### Changed
+- Updated dependencies
+
+## [2.2.3]
+
+### Fixed
+- Handle sub-config tasks in TUI without panicking
+
+## [2.2.0]
+
+### Added
+- `sudo` option for `copy` and `symlink` commands
+
+## [2.0.0]
+
+### Changed
+- Complete rewrite: async engine with TUI, YAML/JSON config, parallel execution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "machine_setup"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "machine_setup"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 description = "A CLI tool with TUI for automating machine configuration and setup tasks"
 license = "MIT OR Apache-2.0"

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,14 +2,4 @@
 
 ## Next
 
-- `depends_on` field for task ordering (DAG-based dependency resolution)
-- conditional tasks: only run if a certain file/directory exists (or doesn't)
 - fix homebrew/tap setup
-- Apple Silicon (aarch64-apple-darwin) native build target
-- JSON examples in documentation
-
-### Low priority
-
-- release script: copy markdown changelog from tag to GitHub release automatically
-- refactor TUI: add task filtering / search
-- task retry on failure

--- a/example_config.json
+++ b/example_config.json
@@ -1,0 +1,113 @@
+{
+  "temp_dir": "~/.machine_setup",
+  "default_shell": "bash",
+  "parallel": false,
+  "tasks": {
+    "greet": {
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'Hello from machine_setup v2!'"
+          }
+        }
+      ]
+    },
+    "multi_step": {
+      "commands": [
+        {
+          "run": {
+            "commands": [
+              "echo 'Step 1: Checking environment...'",
+              "echo 'Step 2: Configuring settings...'",
+              "echo 'Step 3: All done!'"
+            ]
+          }
+        }
+      ]
+    },
+    "with_env_vars": {
+      "commands": [
+        {
+          "run": {
+            "env": {
+              "MY_NAME": "machine_setup",
+              "VERSION": "2.0"
+            },
+            "commands": "echo \"Running $MY_NAME v$VERSION\""
+          }
+        }
+      ]
+    },
+    "mode_specific": {
+      "commands": [
+        {
+          "run": {
+            "install": "echo 'Installing components...'",
+            "update": "echo 'Updating components...'",
+            "uninstall": "echo 'Removing components...'"
+          }
+        }
+      ]
+    },
+    "windows_task": {
+      "os": "windows",
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'This runs only on Windows'"
+          }
+        }
+      ]
+    },
+    "linux_task": {
+      "os": "linux",
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'This runs only on Linux'"
+          }
+        }
+      ]
+    },
+    "macos_task": {
+      "os": "macos",
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'This runs only on macOS'"
+          }
+        }
+      ]
+    },
+    "cross_platform": {
+      "os": ["linux", "macos", "windows"],
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'This runs on all desktop platforms'"
+          }
+        }
+      ]
+    },
+    "parallel_commands": {
+      "parallel": true,
+      "commands": [
+        {
+          "run": {
+            "commands": "echo 'Command A (parallel)'"
+          }
+        },
+        {
+          "run": {
+            "commands": "echo 'Command B (parallel)'"
+          }
+        },
+        {
+          "run": {
+            "commands": "echo 'Command C (parallel)'"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -64,6 +64,22 @@ pub struct TaskConfig {
     /// Run commands within this task in parallel
     #[serde(default)]
     pub parallel: bool,
+
+    /// Only run this task if all these paths exist
+    #[serde(default)]
+    pub only_if: StringOrVec,
+
+    /// Skip this task if any of these paths exist
+    #[serde(default)]
+    pub skip_if: StringOrVec,
+
+    /// Task names that must complete before this task runs
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+
+    /// Number of retry attempts on failure (0 = no retry)
+    #[serde(default)]
+    pub retry: u32,
 }
 
 /// A command entry in the config. Each entry is a single-key map.

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -25,10 +25,116 @@ pub struct ValidationIssue {
     pub severity: Severity,
 }
 
+/// Validate depends_on references exist and detect cycles.
+fn validate_dependencies(config: &AppConfig, issues: &mut Vec<ValidationIssue>) {
+    let task_names: std::collections::HashSet<&str> =
+        config.tasks.keys().map(|s| s.as_str()).collect();
+
+    // Check all depends_on references exist
+    for (name, task) in &config.tasks {
+        for dep in &task.depends_on {
+            if !task_names.contains(dep.as_str()) {
+                issues.push(ValidationIssue {
+                    task_name: name.clone(),
+                    message: format!("depends_on references unknown task: '{dep}'"),
+                    severity: Severity::Error,
+                });
+            }
+        }
+    }
+
+    // Detect cycles using DFS with coloring
+    use std::collections::HashMap;
+    #[derive(PartialEq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+    let mut colors: HashMap<&str, Color> = config
+        .tasks
+        .keys()
+        .map(|k| (k.as_str(), Color::White))
+        .collect();
+
+    fn dfs<'a>(
+        node: &'a str,
+        config: &'a AppConfig,
+        colors: &mut HashMap<&'a str, Color>,
+        path: &mut Vec<&'a str>,
+    ) -> Option<Vec<String>> {
+        colors.insert(node, Color::Gray);
+        path.push(node);
+
+        if let Some(task) = config.tasks.get(node) {
+            for dep in &task.depends_on {
+                match colors.get(dep.as_str()) {
+                    Some(Color::Gray) => {
+                        // Found a cycle — build the cycle path
+                        let cycle_start = path.iter().position(|&n| n == dep.as_str()).unwrap();
+                        let mut cycle: Vec<String> =
+                            path[cycle_start..].iter().map(|s| s.to_string()).collect();
+                        cycle.push(dep.clone());
+                        return Some(cycle);
+                    }
+                    Some(Color::White) | None => {
+                        if let Some(cycle) = dfs(dep, config, colors, path) {
+                            return Some(cycle);
+                        }
+                    }
+                    Some(Color::Black) => {}
+                }
+            }
+        }
+
+        path.pop();
+        colors.insert(node, Color::Black);
+        None
+    }
+
+    let task_keys: Vec<&str> = config.tasks.keys().map(|k| k.as_str()).collect();
+    for &node in &task_keys {
+        if colors.get(node) == Some(&Color::White) {
+            let mut path = Vec::new();
+            if let Some(cycle) = dfs(node, config, &mut colors, &mut path) {
+                issues.push(ValidationIssue {
+                    task_name: cycle[0].clone(),
+                    message: format!("Cyclic dependency detected: {}", cycle.join(" -> ")),
+                    severity: Severity::Error,
+                });
+                break; // Report one cycle at a time
+            }
+        }
+    }
+}
+
 pub fn validate_config(config: &AppConfig, config_dir: &Path) -> Vec<ValidationIssue> {
     let mut issues = Vec::new();
 
+    // Validate depends_on references and detect cycles
+    validate_dependencies(config, &mut issues);
+
     for (name, task) in &config.tasks {
+        // Validate condition paths
+        for path_str in task.only_if.as_slice() {
+            if path_str.trim().is_empty() {
+                issues.push(ValidationIssue {
+                    task_name: name.clone(),
+                    message: "only_if contains an empty path".to_string(),
+                    severity: Severity::Error,
+                });
+            }
+        }
+        for path_str in task.skip_if.as_slice() {
+            if path_str.trim().is_empty() {
+                issues.push(ValidationIssue {
+                    task_name: name.clone(),
+                    message: "skip_if contains an empty path".to_string(),
+                    severity: Severity::Error,
+                });
+            }
+        }
+
         if task.commands.is_empty() {
             issues.push(ValidationIssue {
                 task_name: name.clone(),
@@ -129,6 +235,10 @@ mod tests {
                 commands: vec![],
                 os: Default::default(),
                 parallel: false,
+                only_if: Default::default(),
+                skip_if: Default::default(),
+                depends_on: Default::default(),
+                retry: 0,
             },
         );
         let config = make_config(tasks);
@@ -156,6 +266,10 @@ mod tests {
                 })],
                 os: Default::default(),
                 parallel: false,
+                only_if: Default::default(),
+                skip_if: Default::default(),
+                depends_on: Default::default(),
+                retry: 0,
             },
         );
         let config = make_config(tasks);
@@ -177,6 +291,10 @@ mod tests {
                 })],
                 os: Default::default(),
                 parallel: false,
+                only_if: Default::default(),
+                skip_if: Default::default(),
+                depends_on: Default::default(),
+                retry: 0,
             },
         );
         let config = make_config(tasks);
@@ -201,6 +319,10 @@ mod tests {
                 })],
                 os: Default::default(),
                 parallel: false,
+                only_if: Default::default(),
+                skip_if: Default::default(),
+                depends_on: Default::default(),
+                retry: 0,
             },
         );
         let config = make_config(tasks);
@@ -228,6 +350,10 @@ mod tests {
                 })],
                 os: Default::default(),
                 parallel: false,
+                only_if: Default::default(),
+                skip_if: Default::default(),
+                depends_on: Default::default(),
+                retry: 0,
             },
         );
         let config = make_config(tasks);

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -41,6 +41,14 @@ pub enum TaskEvent {
     /// A task failed.
     TaskFailed { task_name: String, error: String },
 
+    /// A task is being retried after failure.
+    TaskRetry {
+        task_name: String,
+        attempt: u32,
+        max_attempts: u32,
+        error: String,
+    },
+
     /// All tasks are done.
     AllDone {
         succeeded: usize,

--- a/src/engine/runner.rs
+++ b/src/engine/runner.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 
@@ -60,6 +61,9 @@ impl TaskRunner {
 
     /// Run specific tasks by name.
     pub async fn run_tasks(&self, task_names: &[String], force: bool) -> Result<()> {
+        // Resolve dependency order via topological sort
+        let ordered = self.topological_sort(task_names)?;
+
         let temp_dir = expand_path(&self.config.temp_dir, None);
         let mut history = History::load(&temp_dir).unwrap_or_default();
 
@@ -68,81 +72,63 @@ impl TaskRunner {
         let mut skipped = 0usize;
 
         if self.config.parallel {
-            // Parallel execution
-            let mut handles = Vec::new();
+            // Parallel execution with dependency layers
+            let layers = self.dependency_layers(&ordered);
 
-            for name in task_names {
-                let task_config = &self.config.tasks[name];
+            for layer in layers {
+                let mut handles = Vec::new();
 
-                // Check OS filter
-                if !task_config.os.matches_current() {
-                    self.send(TaskEvent::TaskSkipped {
-                        task_name: name.clone(),
-                        reason: "OS mismatch".to_string(),
-                    });
-                    skipped += 1;
-                    continue;
-                }
+                for name in &layer {
+                    let task_config = &self.config.tasks[name];
 
-                // Check history
-                if self.mode == Command::Install && !force && history.is_installed(name) {
-                    self.send(TaskEvent::TaskSkipped {
-                        task_name: name.clone(),
-                        reason: "Already installed (use --force to reinstall)".to_string(),
-                    });
-                    skipped += 1;
-                    continue;
-                }
-
-                let ctx = self.create_context(name, &temp_dir);
-                let task = task_config.clone();
-                let mode = self.mode.clone();
-                let depth = self.depth;
-                let name = name.clone();
-                handles.push(tokio::spawn(async move {
-                    let result = run_task(&name, &task, &ctx, mode, depth).await;
-                    (name, result)
-                }));
-            }
-
-            for handle in handles {
-                match handle.await {
-                    Ok((name, Ok(()))) => {
-                        self.update_history(&mut history, &name);
-                        succeeded += 1;
-                    }
-                    Ok((name, Err(e))) => {
-                        self.send(TaskEvent::TaskFailed {
-                            task_name: name,
-                            error: e.to_string(),
+                    if let Some(reason) = self.should_skip(task_config, name, force, &history) {
+                        self.send(TaskEvent::TaskSkipped {
+                            task_name: name.clone(),
+                            reason,
                         });
-                        failed += 1;
+                        skipped += 1;
+                        continue;
                     }
-                    Err(_) => {
-                        failed += 1;
+
+                    let ctx = self.create_context(name, &temp_dir);
+                    let task = task_config.clone();
+                    let mode = self.mode.clone();
+                    let depth = self.depth;
+                    let name = name.clone();
+                    handles.push(tokio::spawn(async move {
+                        let result = run_task_with_retry(&name, &task, &ctx, mode, depth).await;
+                        (name, result)
+                    }));
+                }
+
+                for handle in handles {
+                    match handle.await {
+                        Ok((name, Ok(()))) => {
+                            self.update_history(&mut history, &name);
+                            succeeded += 1;
+                        }
+                        Ok((name, Err(e))) => {
+                            self.send(TaskEvent::TaskFailed {
+                                task_name: name,
+                                error: e.to_string(),
+                            });
+                            failed += 1;
+                        }
+                        Err(_) => {
+                            failed += 1;
+                        }
                     }
                 }
             }
         } else {
             // Sequential execution
-            for name in task_names {
+            for name in &ordered {
                 let task_config = &self.config.tasks[name];
 
-                // Check OS filter
-                if !task_config.os.matches_current() {
+                if let Some(reason) = self.should_skip(task_config, name, force, &history) {
                     self.send(TaskEvent::TaskSkipped {
                         task_name: name.clone(),
-                        reason: "OS mismatch".to_string(),
-                    });
-                    skipped += 1;
-                    continue;
-                }
-
-                // Check history
-                if self.mode == Command::Install && !force && history.is_installed(name) {
-                    self.send(TaskEvent::TaskSkipped {
-                        task_name: name.clone(),
-                        reason: "Already installed (use --force to reinstall)".to_string(),
+                        reason,
                     });
                     skipped += 1;
                     continue;
@@ -150,7 +136,9 @@ impl TaskRunner {
 
                 let ctx = self.create_context(name, &temp_dir);
 
-                match run_task(name, task_config, &ctx, self.mode.clone(), self.depth).await {
+                match run_task_with_retry(name, task_config, &ctx, self.mode.clone(), self.depth)
+                    .await
+                {
                     Ok(()) => {
                         self.update_history(&mut history, name);
                         succeeded += 1;
@@ -182,6 +170,159 @@ impl TaskRunner {
         } else {
             Ok(())
         }
+    }
+
+    /// Check if a task should be skipped (OS filter, conditions, history).
+    fn should_skip(
+        &self,
+        task: &TaskConfig,
+        name: &str,
+        force: bool,
+        history: &History,
+    ) -> Option<String> {
+        // Check OS filter
+        if !task.os.matches_current() {
+            return Some("OS mismatch".to_string());
+        }
+
+        // Check only_if conditions
+        for path_str in task.only_if.as_slice() {
+            let path = expand_path(path_str, Some(&self.config_dir));
+            if !path.exists() {
+                return Some(format!("Condition not met: '{path_str}' does not exist"));
+            }
+        }
+
+        // Check skip_if conditions
+        for path_str in task.skip_if.as_slice() {
+            let path = expand_path(path_str, Some(&self.config_dir));
+            if path.exists() {
+                return Some(format!("Skipped: '{path_str}' exists"));
+            }
+        }
+
+        // Check history
+        if self.mode == Command::Install && !force && history.is_installed(name) {
+            return Some("Already installed (use --force to reinstall)".to_string());
+        }
+
+        None
+    }
+
+    /// Topological sort of tasks respecting depends_on.
+    /// Returns tasks in dependency order. Includes transitive dependencies
+    /// of the requested tasks.
+    fn topological_sort(&self, requested: &[String]) -> Result<Vec<String>> {
+        let all_tasks = &self.config.tasks;
+
+        // If no task has dependencies, preserve original order
+        let has_deps = requested
+            .iter()
+            .filter_map(|n| all_tasks.get(n))
+            .any(|t| !t.depends_on.is_empty());
+        if !has_deps {
+            return Ok(requested.to_vec());
+        }
+
+        // Collect all needed tasks (requested + transitive deps)
+        let mut needed: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = requested.iter().cloned().collect();
+        while let Some(name) = queue.pop_front() {
+            if needed.contains(&name) {
+                continue;
+            }
+            if let Some(task) = all_tasks.get(&name) {
+                needed.insert(name.clone());
+                for dep in &task.depends_on {
+                    if !all_tasks.contains_key(dep) {
+                        return Err(Error::MissingDependency(name.clone(), dep.clone()));
+                    }
+                    if !needed.contains(dep) {
+                        queue.push_back(dep.clone());
+                    }
+                }
+            }
+        }
+
+        // Build in-degree map for needed tasks
+        let mut in_degree: HashMap<&str, usize> = HashMap::new();
+        let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+        for name in &needed {
+            in_degree.entry(name.as_str()).or_insert(0);
+            if let Some(task) = all_tasks.get(name) {
+                for dep in &task.depends_on {
+                    if needed.contains(dep) {
+                        *in_degree.entry(name.as_str()).or_insert(0) += 1;
+                        dependents
+                            .entry(dep.as_str())
+                            .or_default()
+                            .push(name.as_str());
+                    }
+                }
+            }
+        }
+
+        // Kahn's algorithm
+        let mut queue: VecDeque<&str> = in_degree
+            .iter()
+            .filter(|(_, &deg)| deg == 0)
+            .map(|(&name, _)| name)
+            .collect();
+        let mut sorted = Vec::new();
+
+        while let Some(node) = queue.pop_front() {
+            sorted.push(node.to_string());
+            if let Some(deps) = dependents.get(node) {
+                for &dep in deps {
+                    if let Some(deg) = in_degree.get_mut(dep) {
+                        *deg -= 1;
+                        if *deg == 0 {
+                            queue.push_back(dep);
+                        }
+                    }
+                }
+            }
+        }
+
+        if sorted.len() != needed.len() {
+            let remaining: Vec<String> = needed
+                .iter()
+                .filter(|n| !sorted.contains(n))
+                .cloned()
+                .collect();
+            return Err(Error::CyclicDependency(remaining.join(", ")));
+        }
+
+        Ok(sorted)
+    }
+
+    /// Group tasks into dependency layers for parallel execution.
+    /// Tasks in the same layer have no dependencies on each other.
+    fn dependency_layers(&self, ordered: &[String]) -> Vec<Vec<String>> {
+        let all_tasks = &self.config.tasks;
+        let mut layers: Vec<Vec<String>> = Vec::new();
+        let mut task_layer: HashMap<&str, usize> = HashMap::new();
+
+        for name in ordered {
+            let layer = if let Some(task) = all_tasks.get(name) {
+                task.depends_on
+                    .iter()
+                    .filter_map(|dep| task_layer.get(dep.as_str()))
+                    .max()
+                    .map(|&l| l + 1)
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+
+            task_layer.insert(name.as_str(), layer);
+            while layers.len() <= layer {
+                layers.push(Vec::new());
+            }
+            layers[layer].push(name.clone());
+        }
+
+        layers
     }
 
     /// Get ordered task names (for list command / TUI display).
@@ -220,6 +361,35 @@ impl TaskRunner {
     fn send(&self, event: TaskEvent) {
         let _ = self.event_tx.send(event);
     }
+}
+
+/// Run a task with retry support.
+async fn run_task_with_retry(
+    name: &str,
+    task: &TaskConfig,
+    ctx: &CommandContext,
+    mode: Command,
+    depth: usize,
+) -> Result<()> {
+    let max_attempts = task.retry + 1;
+
+    for attempt in 1..=max_attempts {
+        match run_task(name, task, ctx, mode.clone(), depth).await {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < max_attempts => {
+                let _ = ctx.event_tx.send(TaskEvent::TaskRetry {
+                    task_name: name.to_string(),
+                    attempt,
+                    max_attempts,
+                    error: e.to_string(),
+                });
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    unreachable!()
 }
 
 async fn run_task(

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,12 @@ pub enum Error {
     #[error("History error: {0}")]
     HistoryError(String),
 
+    #[error("Cyclic dependency detected: {0}")]
+    CyclicDependency(String),
+
+    #[error("Unknown dependency: task '{0}' depends on '{1}' which does not exist")]
+    MissingDependency(String, String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -69,10 +69,17 @@ pub struct App {
     pub skipped: usize,
     /// Auto-follow: track the first running task
     pub auto_select: bool,
+    /// Whether the search input is active
+    pub search_mode: bool,
+    /// Current search query
+    pub search_query: String,
+    /// Indices into `tasks` that match the current filter
+    pub filtered_indices: Vec<usize>,
 }
 
 impl App {
     pub fn new(task_names: Vec<String>, mode: Command) -> Self {
+        let filtered_indices: Vec<usize> = (0..task_names.len()).collect();
         let tasks = task_names.into_iter().map(TaskState::new).collect();
         Self {
             tasks,
@@ -84,6 +91,9 @@ impl App {
             failed: 0,
             skipped: 0,
             auto_select: true,
+            search_mode: false,
+            search_query: String::new(),
+            filtered_indices,
         }
     }
 
@@ -156,6 +166,18 @@ impl App {
                 task.log_lines.push(format!("FAILED: {error}"));
                 self.failed += 1;
             }
+            TaskEvent::TaskRetry {
+                task_name,
+                attempt,
+                max_attempts,
+                error,
+            } => {
+                let task = self.find_or_create_task(&task_name);
+                task.status = TaskStatus::Running;
+                task.log_lines
+                    .push(format!("  Retry {attempt}/{max_attempts}: {error}"));
+                self.auto_scroll_log();
+            }
             TaskEvent::AllDone { .. } => {
                 self.done = true;
             }
@@ -164,16 +186,85 @@ impl App {
 
     pub fn select_next(&mut self) {
         self.auto_select = false;
-        if !self.tasks.is_empty() {
-            self.selected = (self.selected + 1).min(self.tasks.len() - 1);
-            self.log_scroll = 0;
+        if self.filtered_indices.is_empty() {
+            return;
         }
+        // Find the next filtered index after current selection
+        if let Some(pos) = self
+            .filtered_indices
+            .iter()
+            .position(|&i| i > self.selected)
+        {
+            self.selected = self.filtered_indices[pos];
+        }
+        self.log_scroll = 0;
     }
 
     pub fn select_prev(&mut self) {
         self.auto_select = false;
-        self.selected = self.selected.saturating_sub(1);
+        if self.filtered_indices.is_empty() {
+            return;
+        }
+        // Find the previous filtered index before current selection
+        if let Some(pos) = self
+            .filtered_indices
+            .iter()
+            .rposition(|&i| i < self.selected)
+        {
+            self.selected = self.filtered_indices[pos];
+        }
         self.log_scroll = 0;
+    }
+
+    /// Enter search mode.
+    pub fn enter_search(&mut self) {
+        self.search_mode = true;
+        self.search_query.clear();
+        self.update_filter();
+    }
+
+    /// Exit search mode and clear the filter.
+    pub fn exit_search(&mut self) {
+        self.search_mode = false;
+        self.search_query.clear();
+        self.update_filter();
+    }
+
+    /// Confirm search: exit search mode but keep the filter active.
+    pub fn confirm_search(&mut self) {
+        self.search_mode = false;
+    }
+
+    /// Append a character to the search query.
+    pub fn search_push_char(&mut self, c: char) {
+        self.search_query.push(c);
+        self.update_filter();
+    }
+
+    /// Remove the last character from the search query.
+    pub fn search_pop_char(&mut self) {
+        self.search_query.pop();
+        self.update_filter();
+    }
+
+    /// Recalculate filtered indices based on the search query.
+    fn update_filter(&mut self) {
+        let query = self.search_query.to_lowercase();
+        self.filtered_indices = self
+            .tasks
+            .iter()
+            .enumerate()
+            .filter(|(_, task)| query.is_empty() || task.name.to_lowercase().contains(&query))
+            .map(|(i, _)| i)
+            .collect();
+
+        // If selected is no longer in filtered set, jump to nearest match
+        if !self.filtered_indices.contains(&self.selected) {
+            if let Some(&first) = self.filtered_indices.first() {
+                self.selected = first;
+                self.log_scroll = 0;
+            }
+        }
     }
 
     pub fn scroll_log_down(&mut self) {
@@ -209,7 +300,13 @@ impl App {
     /// Find a task by name, or create it if it doesn't exist (e.g. sub-config tasks).
     fn find_or_create_task(&mut self, name: &str) -> &mut TaskState {
         if !self.tasks.iter().any(|t| t.name == name) {
+            let idx = self.tasks.len();
             self.tasks.push(TaskState::new(name.to_string()));
+            // Add to filtered indices if it matches the current filter
+            let query = self.search_query.to_lowercase();
+            if query.is_empty() || name.to_lowercase().contains(&query) {
+                self.filtered_indices.push(idx);
+            }
         }
         self.tasks.iter_mut().find(|t| t.name == name).unwrap()
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -84,22 +84,37 @@ async fn run_loop(
         // Handle keyboard input (with timeout for responsive UI)
         if event::poll(Duration::from_millis(50))? {
             if let Event::Key(key) = event::read()? {
-                match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => {
-                        cancel.cancel();
-                        return Ok(());
+                // Ctrl+C always quits
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                    cancel.cancel();
+                    return Ok(());
+                }
+
+                if app.search_mode {
+                    match key.code {
+                        KeyCode::Esc => app.exit_search(),
+                        KeyCode::Enter => app.confirm_search(),
+                        KeyCode::Backspace => app.search_pop_char(),
+                        KeyCode::Char(c) => app.search_push_char(c),
+                        KeyCode::Up => app.select_prev(),
+                        KeyCode::Down => app.select_next(),
+                        _ => {}
                     }
-                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        cancel.cancel();
-                        return Ok(());
+                } else {
+                    match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => {
+                            cancel.cancel();
+                            return Ok(());
+                        }
+                        KeyCode::Char('/') => app.enter_search(),
+                        KeyCode::Up | KeyCode::Char('k') => app.select_prev(),
+                        KeyCode::Down | KeyCode::Char('j') => app.select_next(),
+                        KeyCode::PageUp => app.scroll_log_up(),
+                        KeyCode::PageDown => app.scroll_log_down(),
+                        KeyCode::Home => app.scroll_log_to_top(),
+                        KeyCode::End => app.scroll_log_to_bottom(),
+                        _ => {}
                     }
-                    KeyCode::Up | KeyCode::Char('k') => app.select_prev(),
-                    KeyCode::Down | KeyCode::Char('j') => app.select_next(),
-                    KeyCode::PageUp => app.scroll_log_up(),
-                    KeyCode::PageDown => app.scroll_log_down(),
-                    KeyCode::Home => app.scroll_log_to_top(),
-                    KeyCode::End => app.scroll_log_to_bottom(),
-                    _ => {}
                 }
             }
         }

--- a/src/tui/plain.rs
+++ b/src/tui/plain.rs
@@ -45,6 +45,14 @@ pub async fn run(mut event_rx: mpsc::UnboundedReceiver<TaskEvent>) {
             TaskEvent::TaskFailed { task_name, error } => {
                 eprintln!("XX {task_name}: {error}");
             }
+            TaskEvent::TaskRetry {
+                task_name,
+                attempt,
+                max_attempts,
+                error,
+            } => {
+                println!("   [{task_name}]   Retry {attempt}/{max_attempts}: {error}");
+            }
             TaskEvent::AllDone {
                 succeeded,
                 failed,

--- a/src/tui/widgets/help_bar.rs
+++ b/src/tui/widgets/help_bar.rs
@@ -7,13 +7,24 @@ use ratatui::Frame;
 use crate::tui::app::App;
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
-    let keys = if app.done {
-        vec![key_hint("q", "quit"), key_hint("Up/Down", "navigate")]
+    let keys = if app.search_mode {
+        vec![
+            key_hint("Esc", "cancel"),
+            key_hint("Enter", "apply"),
+            key_hint("Up/Down", "navigate"),
+        ]
+    } else if app.done {
+        vec![
+            key_hint("q", "quit"),
+            key_hint("Up/Down", "navigate"),
+            key_hint("/", "search"),
+        ]
     } else {
         vec![
             key_hint("q", "quit"),
             key_hint("Up/Down", "navigate"),
             key_hint("PgUp/PgDn", "scroll log"),
+            key_hint("/", "search"),
         ]
     };
 

--- a/src/tui/widgets/task_list.rs
+++ b/src/tui/widgets/task_list.rs
@@ -1,16 +1,31 @@
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 use ratatui::Frame;
 
 use crate::tui::app::{App, TaskStatus};
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
+    // Split area: main task list + optional search bar at bottom
+    let (list_area, search_area) = if app.search_mode || !app.search_query.is_empty() {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        (chunks[0], Some(chunks[1]))
+    } else {
+        (area, None)
+    };
+
+    let filtered_set: std::collections::HashSet<usize> =
+        app.filtered_indices.iter().copied().collect();
+
     let items: Vec<ListItem> = app
         .tasks
         .iter()
         .enumerate()
+        .filter(|(i, _)| filtered_set.contains(i))
         .map(|(i, task)| {
             let (symbol, style) = match &task.status {
                 TaskStatus::Pending => ("  ", Style::default().fg(Color::DarkGray)),
@@ -58,6 +73,9 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
 
+    // Compute which filtered position is selected
+    let selected_pos = app.filtered_indices.iter().position(|&i| i == app.selected);
+
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
@@ -71,7 +89,27 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     );
 
     let mut state = ListState::default();
-    state.select(Some(app.selected));
+    state.select(selected_pos);
 
-    f.render_stateful_widget(list, area, &mut state);
+    f.render_stateful_widget(list, list_area, &mut state);
+
+    // Render search bar if active or has a query
+    if let Some(search_area) = search_area {
+        let search_line = Line::from(vec![
+            Span::styled(
+                "/",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(&app.search_query, Style::default().fg(Color::White)),
+            if app.search_mode {
+                Span::styled("_", Style::default().fg(Color::Cyan))
+            } else {
+                Span::raw("")
+            },
+        ]);
+        let search = Paragraph::new(search_line);
+        f.render_widget(search, search_area);
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -668,3 +668,353 @@ tasks:
         && i.message.contains("no commands")
         && matches!(i.severity, validate::Severity::Warning)));
 }
+
+// ─── Conditional task tests (only_if / skip_if) ───
+
+#[tokio::test]
+async fn test_only_if_path_exists_runs() {
+    let dir = tempdir().unwrap();
+    let marker = dir.path().join("marker_file");
+    fs::write(&marker, "").unwrap();
+
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+tasks:
+  conditional:
+    only_if: "{}"
+    commands:
+      - run:
+          commands: "echo only_if_ran"
+"#,
+            marker.to_string_lossy().replace('\\', "/")
+        ),
+    )
+    .unwrap();
+
+    let config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let runner =
+        TaskRunner::new(config, Command::Install, tx).with_config_dir(dir.path().to_path_buf());
+    let _ = runner.run_all(true).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+
+    assert!(task_completed(&events, "conditional"));
+    assert!(find_output(&events, "conditional", "only_if_ran"));
+}
+
+#[tokio::test]
+async fn test_only_if_path_missing_skips() {
+    let events = run_config(
+        r#"
+tasks:
+  conditional:
+    only_if: "/nonexistent/path/that/should/not/exist"
+    commands:
+      - run:
+          commands: "echo should_not_run"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    assert!(task_skipped(&events, "conditional"));
+    assert!(!find_output(&events, "conditional", "should_not_run"));
+}
+
+#[tokio::test]
+async fn test_skip_if_path_exists_skips() {
+    let dir = tempdir().unwrap();
+    let marker = dir.path().join("skip_marker");
+    fs::write(&marker, "").unwrap();
+
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+tasks:
+  conditional:
+    skip_if: "{}"
+    commands:
+      - run:
+          commands: "echo should_not_run"
+"#,
+            marker.to_string_lossy().replace('\\', "/")
+        ),
+    )
+    .unwrap();
+
+    let config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let runner =
+        TaskRunner::new(config, Command::Install, tx).with_config_dir(dir.path().to_path_buf());
+    let _ = runner.run_all(true).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+
+    assert!(task_skipped(&events, "conditional"));
+}
+
+#[tokio::test]
+async fn test_skip_if_path_missing_runs() {
+    let events = run_config(
+        r#"
+tasks:
+  conditional:
+    skip_if: "/nonexistent/path/that/should/not/exist"
+    commands:
+      - run:
+          commands: "echo skip_if_ran"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    assert!(task_completed(&events, "conditional"));
+    assert!(find_output(&events, "conditional", "skip_if_ran"));
+}
+
+// ─── Dependency ordering tests (depends_on) ───
+
+#[tokio::test]
+async fn test_depends_on_ordering() {
+    let events = run_config(
+        r#"
+tasks:
+  second:
+    depends_on: ["first"]
+    commands:
+      - run:
+          commands: "echo second_task"
+  first:
+    commands:
+      - run:
+          commands: "echo first_task"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    assert!(task_completed(&events, "first"));
+    assert!(task_completed(&events, "second"));
+
+    // Verify first completed before second started
+    let first_done = events
+        .iter()
+        .position(|e| matches!(e, TaskEvent::TaskCompleted { task_name } if task_name == "first"));
+    let second_start = events.iter().position(
+        |e| matches!(e, TaskEvent::TaskStarted { task_name, .. } if task_name == "second"),
+    );
+    assert!(first_done.is_some());
+    assert!(second_start.is_some());
+    assert!(first_done.unwrap() < second_start.unwrap());
+}
+
+#[tokio::test]
+async fn test_depends_on_transitive() {
+    let events = run_config(
+        r#"
+tasks:
+  c:
+    depends_on: ["b"]
+    commands:
+      - run:
+          commands: "echo task_c"
+  b:
+    depends_on: ["a"]
+    commands:
+      - run:
+          commands: "echo task_b"
+  a:
+    commands:
+      - run:
+          commands: "echo task_a"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    assert!(task_completed(&events, "a"));
+    assert!(task_completed(&events, "b"));
+    assert!(task_completed(&events, "c"));
+
+    // Verify order: a before b, b before c
+    let a_done = events
+        .iter()
+        .position(|e| matches!(e, TaskEvent::TaskCompleted { task_name } if task_name == "a"))
+        .unwrap();
+    let b_start = events
+        .iter()
+        .position(|e| matches!(e, TaskEvent::TaskStarted { task_name, .. } if task_name == "b"))
+        .unwrap();
+    let b_done = events
+        .iter()
+        .position(|e| matches!(e, TaskEvent::TaskCompleted { task_name } if task_name == "b"))
+        .unwrap();
+    let c_start = events
+        .iter()
+        .position(|e| matches!(e, TaskEvent::TaskStarted { task_name, .. } if task_name == "c"))
+        .unwrap();
+
+    assert!(a_done < b_start);
+    assert!(b_done < c_start);
+}
+
+#[tokio::test]
+async fn test_depends_on_cycle_detected() {
+    use machine_setup::config::validate;
+
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        r#"
+tasks:
+  a:
+    depends_on: ["b"]
+    commands:
+      - run:
+          commands: "echo a"
+  b:
+    depends_on: ["a"]
+    commands:
+      - run:
+          commands: "echo b"
+"#,
+    )
+    .unwrap();
+
+    let config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    let issues = validate::validate_config(&config, dir.path());
+    assert!(issues
+        .iter()
+        .any(|i| i.message.contains("Cyclic dependency")));
+}
+
+#[tokio::test]
+async fn test_depends_on_missing_dependency() {
+    use machine_setup::config::validate;
+
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        r#"
+tasks:
+  a:
+    depends_on: ["nonexistent"]
+    commands:
+      - run:
+          commands: "echo a"
+"#,
+    )
+    .unwrap();
+
+    let config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    let issues = validate::validate_config(&config, dir.path());
+    assert!(issues
+        .iter()
+        .any(|i| i.message.contains("unknown task") && i.message.contains("nonexistent")));
+}
+
+// ─── Retry tests ───
+
+#[tokio::test]
+async fn test_retry_on_failure() {
+    let dir = tempdir().unwrap();
+    let counter_file = dir.path().join("counter");
+
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+tasks:
+  retryable:
+    retry: 2
+    commands:
+      - run:
+          commands: "if [ -f '{}' ]; then echo retry_success; else touch '{}' && exit 1; fi"
+"#,
+            counter_file.to_string_lossy().replace('\\', "/"),
+            counter_file.to_string_lossy().replace('\\', "/"),
+        ),
+    )
+    .unwrap();
+
+    let mut config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    config.temp_dir = dir.path().join(".ms_temp").to_string_lossy().to_string();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let runner =
+        TaskRunner::new(config, Command::Install, tx).with_config_dir(dir.path().to_path_buf());
+    let _ = runner.run_all(true).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+
+    // Should have a retry event and eventual success
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TaskEvent::TaskRetry { task_name, .. } if task_name == "retryable")));
+    assert!(task_completed(&events, "retryable"));
+    assert!(find_output(&events, "retryable", "retry_success"));
+}
+
+#[tokio::test]
+async fn test_retry_exhausted_fails() {
+    let events = run_config(
+        r#"
+tasks:
+  always_fails:
+    retry: 1
+    commands:
+      - run:
+          commands: "exit 1"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    // Should have a retry event but still fail
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TaskEvent::TaskRetry { .. })));
+    assert!(task_failed(&events, "always_fails"));
+}
+
+#[tokio::test]
+async fn test_no_retry_by_default() {
+    let events = run_config(
+        r#"
+tasks:
+  no_retry:
+    commands:
+      - run:
+          commands: "exit 1"
+"#,
+        Command::Install,
+    )
+    .await;
+
+    // Should NOT have any retry events
+    assert!(!events
+        .iter()
+        .any(|e| matches!(e, TaskEvent::TaskRetry { .. })));
+    assert!(task_failed(&events, "no_retry"));
+}


### PR DESCRIPTION
## Summary
- **`depends_on`**: DAG-based task dependency resolution with topological sort, cycle detection in validation, and layered parallel execution that respects dependency order
- **`only_if` / `skip_if`**: Conditional tasks that run (or skip) based on file/directory existence — supports `~` expansion and multiple paths
- **`retry`**: Configurable retry count for flaky tasks (e.g., network downloads), with 1s delay between attempts and retry events in both TUI and plain output
- **TUI search**: Press `/` to filter the task list by name, `Enter` to apply, `Esc` to cancel
- **JSON example config**: `example_config.json` as a 1:1 translation of the YAML example
- **CHANGELOG.md**: Keep a Changelog format with automatic release note extraction in the CI workflow (falls back to GitHub auto-generated notes if no entry exists)
- Version bump to 2.4.0

All changes are backward-compatible — existing configs work without modification.

## Test plan
- [x] 77 tests pass (46 unit + 31 integration), including 11 new tests covering all new features
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo run -- validate -c ./example_config.json` succeeds
- [ ] Manual TUI testing: run `cargo run -- install -c ./example_config.yaml` and verify `/` search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)