### PR TITLE
feat: command-speed benches, concurrency gate, and SudoFs hybrid

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,8 +43,9 @@ entry type, behind the `CommandExecutor` interface (single `execute` method).
 _Avoid_: handler, command (see Flagged ambiguities).
 
 **Task event**:
-A message emitted by the runner describing execution progress, consumed by the
-TUI or the plain logger (`TaskEvent`).
+A message describing execution progress (`TaskEvent`) — lifecycle and
+per-line/per-file output alike. Emitted through the **Task event sink**; the
+TUI and plain logger consume events from the channel-backed adapter.
 _Avoid_: message, log, signal.
 
 **History**:
@@ -61,33 +62,63 @@ should refer to them by these names.
 The single home for everything derived from `depends_on` edges — topological
 order, parallel layers, cycle detection, and missing-edge detection
 (`TaskGraph`). Both the runner and the validator read from it.
-_Avoid_: dependency resolver, DAG, scheduler.
+_Avoid_: dependency resolver, DAG, scheduler (do not reuse "scheduler" for
+concurrency — see **Concurrency gate**).
+
+**Task event sink**:
+The seam for emitting **Task events**. Adapters: **ChannelSink** (mpsc →
+TUI/plain) and **NullSink** (benches). The Runner and `CommandContext` both
+emit through this interface — not a raw sender.
+_Avoid_: logger, event bus, observer.
+
+**Concurrency gate**:
+The Runner's global cap on in-flight leaf Command executor work, driven by
+`num_threads` (default: physical CPUs − 1). Permits are per Command entry;
+`machine_setup` does not hold a permit so nested Sub-configs can share the
+gate. Sync File ops work runs via `spawn_blocking` so it does not block Tokio
+workers. Does **not** order Tasks by dependency — that remains the **Task graph**.
+_Avoid_: scheduler, thread pool (until a dedicated FS pool exists).
 
 **File ops**:
 The privilege seam for filesystem primitives (`mkdir`, copy, symlink, removal),
 with two adapters — **DirectFs** (`std::fs`) and **SudoFs** (`sudo`) — chosen
-once per command from its `sudo` flag (`FileOps`).
+once per command from its `sudo` flag (`FileOps`). SudoFs may script-batch
+per-file ops and flush once; eligible directory `copy` installs may use a bulk
+privileged path. Symlink sudo stays script-batched.
 _Avoid_: fs helper, file utils.
 
 **Tree materialization**:
 The shared traversal behind `copy` and `symlink`: destination resolution (the
 file-vs-directory target rule) plus the install/uninstall walk, parameterized by
-a per-file operation.
+a per-file operation. In-tree parallel file apply is deferred until Command
+bench numbers show DirectFs walk/apply as the next cliff.
 _Avoid_: file walker, copier.
+
+**Command bench**:
+The measurement module for Command executor / Tree materialization / Runner
+wall-clock speed — Criterion microbenches plus thin Runner smoke over
+generate-once fixtures. Report-only (no absolute ms CI asserts). SudoFs cases
+opt-in via `MACHINE_SETUP_BENCH_SUDO=1`.
+_Avoid_: performance test (ambiguous with correctness tests), profiling.
 
 ## Relationships
 
 - A **Task** contains one or more **Command entries** and may declare
   dependencies on other tasks.
 - The **Task graph** orders **Tasks**; the **Runner** executes them in that
-  order under one **Mode**.
+  order under one **Mode**, admitting work through the **Concurrency gate**.
+  Nested **Sub-config** Runners share the parent's **Concurrency gate**.
 - The **Runner** turns each **Command entry** into a **Command executor** and
   calls `execute`, which acts according to the current **Mode**.
 - The `copy` and `symlink` **Command executors** drive **Tree materialization**,
-  which performs each file operation through a **File ops** adapter.
+  which performs each file operation through a **File ops** adapter (executors
+  may choose a bulk SudoFs path when eligible).
 - A `machine_setup` **Command entry** loads a **Sub-config** and runs it with a
   nested **Runner**.
-- The **Runner** emits **Task events** and consults/updates **History**.
+- The **Runner** and Command executors emit **Task events** through the
+  **Task event sink** and consult/update **History**.
+- The **Command bench** exercises Tree materialization, File ops, and the
+  Runner across the same seams production uses (NullSink in smoke runs).
 
 ## Example dialogue
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +244,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -349,10 +388,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -380,6 +482,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -626,10 +734,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-sink"
@@ -650,6 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -700,6 +839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +876,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -814,10 +970,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -953,6 +1129,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "criterion",
  "crossterm",
  "dialoguer",
  "dirs",
@@ -1108,6 +1285,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -1287,6 +1470,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,7 +1580,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -1434,7 +1645,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -1442,6 +1653,26 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1991,6 +2222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,7 +2402,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2326,6 +2567,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2602,6 +2853,26 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,8 @@ winresource = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+
+[[bench]]
+name = "command_bench"
+harness = false

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ lint:
 	cargo fmt --all -- --check
 	cargo clippy -- -D warnings
 
+bench:
+	cargo bench --bench command_bench
+
 build:
 	cargo build --release
 

--- a/benches/command_bench.rs
+++ b/benches/command_bench.rs
@@ -1,0 +1,310 @@
+//! Command bench — Criterion micro + Runner smoke (ADR-0001 report-only).
+//!
+//! Generate-once fixtures per process; SudoFs cases require
+//! `MACHINE_SETUP_BENCH_SUDO=1`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use tempfile::TempDir;
+
+use machine_setup::config;
+use machine_setup::engine::commands::fs_ops::{self, DirectFs, FileOps};
+use machine_setup::engine::commands::tree::{self, install_tree, uninstall_tree};
+use machine_setup::engine::mode::Mode;
+use machine_setup::engine::runner::TaskRunner;
+use machine_setup::engine::sink::NullSink;
+
+const N_FILES: usize = 1_000;
+
+struct TreeFixture {
+    _root: TempDir,
+    src: PathBuf,
+}
+
+impl TreeFixture {
+    fn generate(n_files: usize) -> Self {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("src");
+        fs::create_dir_all(src.join("a/b")).expect("mkdir");
+        for i in 0..n_files {
+            let sub = if i % 3 == 0 {
+                src.join("a/b")
+            } else if i % 3 == 1 {
+                src.join("a")
+            } else {
+                src.clone()
+            };
+            fs::write(sub.join(format!("f{i}.txt")), format!("payload-{i}")).expect("write");
+        }
+        Self { _root: root, src }
+    }
+
+    fn src(&self) -> &Path {
+        &self.src
+    }
+}
+
+fn fixture_1k() -> &'static TreeFixture {
+    static FIXTURE: OnceLock<TreeFixture> = OnceLock::new();
+    FIXTURE.get_or_init(|| TreeFixture::generate(N_FILES))
+}
+
+fn sudo_enabled() -> bool {
+    std::env::var_os("MACHINE_SETUP_BENCH_SUDO").is_some_and(|v| v != "0")
+}
+
+fn copy_tree(ops: &dyn FileOps, src: &Path, dest: &Path) {
+    install_tree(
+        src,
+        dest,
+        &[],
+        |dir| ops.mkdir_p(dir),
+        |file, dest| ops.copy_file(file, dest),
+    )
+    .expect("install_tree copy");
+}
+
+fn link_tree(ops: &dyn FileOps, src: &Path, dest: &Path) {
+    install_tree(
+        src,
+        dest,
+        &[],
+        |dir| tree::ensure_real_dir(ops, dir, |_| {}),
+        |file, dest| ops.create_symlink(file, dest),
+    )
+    .expect("install_tree symlink");
+}
+
+fn bench_tree_install_direct(c: &mut Criterion) {
+    let fixture = fixture_1k();
+    let ops = DirectFs;
+    let mut group = c.benchmark_group("tree_install_direct");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.bench_function("1k_files", |b| {
+        b.iter_batched(
+            || tempfile::tempdir().expect("dest"),
+            |dest| {
+                copy_tree(&ops, fixture.src(), dest.path());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_tree_install_sudo(c: &mut Criterion) {
+    if !sudo_enabled() {
+        return;
+    }
+    let fixture = fixture_1k();
+    let ops = fs_ops::select(true);
+    let mut group = c.benchmark_group("tree_install_sudo");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+    group.bench_function("1k_files", |b| {
+        b.iter_batched(
+            || tempfile::tempdir().expect("dest"),
+            |dest| {
+                copy_tree(ops.as_ref(), fixture.src(), dest.path());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_mtime_skip(c: &mut Criterion) {
+    let fixture = fixture_1k();
+    let ops = DirectFs;
+    let synced = tempfile::tempdir().expect("synced");
+    copy_tree(&ops, fixture.src(), synced.path());
+
+    let mut group = c.benchmark_group("mtime_skip");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.bench_function("1k_already_synced", |b| {
+        b.iter(|| {
+            install_tree(
+                fixture.src(),
+                synced.path(),
+                &[],
+                |dir| ops.mkdir_p(dir),
+                |src, dest| {
+                    if dest.exists() {
+                        if let (Ok(sm), Ok(dm)) = (fs::metadata(src), fs::metadata(dest)) {
+                            if let (Ok(smod), Ok(dmod)) = (sm.modified(), dm.modified()) {
+                                if dmod >= smod {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                    ops.copy_file(src, dest)
+                },
+            )
+            .expect("mtime skip walk");
+        });
+    });
+    group.finish();
+}
+
+fn bench_symlink_tree(c: &mut Criterion) {
+    let fixture = fixture_1k();
+    let ops = DirectFs;
+    let mut group = c.benchmark_group("tree_symlink_direct");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.bench_function("1k_files", |b| {
+        b.iter_batched(
+            || tempfile::tempdir().expect("dest"),
+            |dest| {
+                link_tree(&ops, fixture.src(), dest.path());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_uninstall_tree(c: &mut Criterion) {
+    let fixture = fixture_1k();
+    let ops = DirectFs;
+    let mut group = c.benchmark_group("tree_uninstall_direct");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.bench_function("1k_files", |b| {
+        b.iter_batched(
+            || {
+                let dest = tempfile::tempdir().expect("dest");
+                copy_tree(&ops, fixture.src(), dest.path());
+                dest
+            },
+            |dest| {
+                uninstall_tree(fixture.src(), dest.path(), &[], |path| {
+                    if path.exists() {
+                        ops.remove_file(path)?;
+                    }
+                    Ok(())
+                })
+                .expect("uninstall_tree");
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+struct RunnerCase {
+    work: TempDir,
+    cfg_path: PathBuf,
+    cfg_dir: PathBuf,
+}
+
+fn prepare_runner_case(fixture_src: &Path, parallel: bool) -> RunnerCase {
+    let work = tempfile::tempdir().expect("work");
+    let cfg_dir = work.path().join("cfg");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    let dest_a = work.path().join("out_a");
+    let dest_b = work.path().join("out_b");
+    let yaml = if parallel {
+        format!(
+            r#"
+default_shell: bash
+parallel: true
+temp_dir: {temp}
+tasks:
+  copy_a:
+    commands:
+      - copy:
+          src: "{src}"
+          target: "{dest_a}"
+  copy_b:
+    commands:
+      - copy:
+          src: "{src}"
+          target: "{dest_b}"
+"#,
+            temp = work.path().join("ms").display(),
+            src = fixture_src.display(),
+            dest_a = dest_a.display(),
+            dest_b = dest_b.display(),
+        )
+    } else {
+        format!(
+            r#"
+default_shell: bash
+parallel: false
+temp_dir: {temp}
+tasks:
+  copy_tree:
+    commands:
+      - copy:
+          src: "{src}"
+          target: "{dest}"
+"#,
+            temp = work.path().join("ms").display(),
+            src = fixture_src.display(),
+            dest = dest_a.display(),
+        )
+    };
+    let cfg_path = cfg_dir.join("config.yaml");
+    fs::write(&cfg_path, yaml).unwrap();
+    RunnerCase {
+        work,
+        cfg_path,
+        cfg_dir,
+    }
+}
+
+async fn run_case(case: RunnerCase) {
+    let mut config = config::load_config(case.cfg_path.to_str().unwrap()).unwrap();
+    config.temp_dir = case.work.path().join("ms").to_string_lossy().into();
+    let runner =
+        TaskRunner::new(config, Mode::Install, NullSink::shared()).with_config_dir(case.cfg_dir);
+    runner.run_all(true).await.expect("run");
+}
+
+fn bench_runner_smoke(c: &mut Criterion) {
+    let fixture = fixture_1k();
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let mut group = c.benchmark_group("runner_smoke");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(4));
+
+    group.bench_function("single_copy_1k_null_sink", |b| {
+        b.to_async(&rt).iter_batched(
+            || prepare_runner_case(fixture.src(), false),
+            |case| run_case(case),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("parallel_two_copy_tasks_1k", |b| {
+        b.to_async(&rt).iter_batched(
+            || prepare_runner_case(fixture.src(), true),
+            |case| run_case(case),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_tree_install_direct,
+    bench_tree_install_sudo,
+    bench_mtime_skip,
+    bench_symlink_tree,
+    bench_uninstall_tree,
+    bench_runner_smoke,
+);
+criterion_main!(benches);

--- a/docs/adr/0001-command-bench-report-only.md
+++ b/docs/adr/0001-command-bench-report-only.md
@@ -1,0 +1,7 @@
+# Command bench budgets are report-only
+
+We measure Command executor / Tree materialization / Runner wall-clock with
+Criterion (**Command bench**) but do **not** fail CI on absolute millisecond
+budgets. Machine and WSL noise make hard asserts flaky. Soft Criterion baseline
+comparison in CI is a deliberate follow-up once we have stable local numbers —
+not part of the first land.

--- a/docs/adr/0002-sudo-hybrid-via-executors.md
+++ b/docs/adr/0002-sudo-hybrid-via-executors.md
@@ -1,0 +1,8 @@
+# SudoFs hybrid lives in copy/symlink executors (not FileOps apply_tree yet)
+
+Privileged directory `copy` may take a bulk path when eligible (empty ignore,
+no mtime-skip semantics); otherwise SudoFs script-batches per-file ops and
+flushes once. Symlink sudo stays script-batched only. Executors choose bulk vs
+`install_tree` + flush because they already know `sudo`, ignore, and mode.
+Deepening **File ops** toward a shared `apply_tree` planner is deferred — reopen
+when executor privilege branches become the friction, not before.

--- a/docs/adr/0003-concurrency-gate-global.md
+++ b/docs/adr/0003-concurrency-gate-global.md
@@ -1,0 +1,12 @@
+# One Concurrency gate for Command entries (shared with nested Sub-configs)
+
+`num_threads` caps in-flight leaf Command executor work under one semaphore
+(default: physical CPUs − 1). Permits are acquired per Command entry — not per
+Task — so sequential and `parallel: true` Tasks share the same rule. The
+`machine_setup` Command entry does **not** occupy a slot while it runs; nested
+Sub-config Runners share the parent's gate and their leaf commands acquire
+normally. That avoids a deadlock when `num_threads: 1` and a parent Task would
+otherwise hold the only permit across nested work. Sync File ops (`copy` /
+`symlink`) run via `spawn_blocking`. We accepted that a fat `parallel: true`
+Task can starve siblings; per-Task sub-quotas are a future fix. A dedicated FS
+thread pool waits until in-tree parallel apply needs it.

--- a/docs/adr/0004-defer-parallel-tree-materialization.md
+++ b/docs/adr/0004-defer-parallel-tree-materialization.md
@@ -1,0 +1,7 @@
+# Defer parallel file apply inside Tree materialization
+
+In-tree concurrent `on_file` for DirectFs is deferred until Command bench
+baselines show sequential walk/apply as the next cliff after SudoFs hybrid and
+the Concurrency gate. Keep the `install_tree` / `uninstall_tree` interface;
+parallelism would be implementation-only. Do not introduce a second concurrency
+knob independent of `num_threads`.

--- a/docs/adr/0005-task-event-sink.md
+++ b/docs/adr/0005-task-event-sink.md
@@ -1,0 +1,8 @@
+# All Task events go through TaskEventSink
+
+The Runner and CommandContext emit every TaskEvent through a **Task event
+sink**, not a raw `mpsc` sender. Adapters: **ChannelSink** (production →
+TUI/plain) and **NullSink** (Command bench smoke). This isolates FS/Runner
+wall-clock from event clone/channel cost and keeps one seam for lifecycle and
+CommandOutput alike. Fan-out to multiple simultaneous consumers was rejected as
+overbuilt for a single UI consumer.

--- a/src/engine/commands/copy.rs
+++ b/src/engine/commands/copy.rs
@@ -24,10 +24,17 @@ impl CopyCommand {
 #[async_trait]
 impl CommandExecutor for CopyCommand {
     async fn execute(&self, ctx: &CommandContext) -> Result<()> {
-        match ctx.mode {
-            Mode::Install | Mode::Update => self.apply(ctx),
-            Mode::Uninstall => self.remove(ctx),
-        }
+        let args = self.args.clone();
+        let ctx = ctx.clone();
+        tokio::task::spawn_blocking(move || {
+            let cmd = CopyCommand { args };
+            match ctx.mode {
+                Mode::Install | Mode::Update => cmd.apply(&ctx),
+                Mode::Uninstall => cmd.remove(&ctx),
+            }
+        })
+        .await
+        .map_err(|e| Error::Other(e.to_string()))?
     }
 
     fn description(&self) -> String {
@@ -36,6 +43,12 @@ impl CommandExecutor for CopyCommand {
 }
 
 impl CopyCommand {
+    /// Directory Install with empty ignore → one `sudo cp -a` (ADR-0002).
+    /// Update keeps mtime-skip via per-file + script batch.
+    fn eligible_for_bulk(src: &Path, args: &CopyArgs, mode: Mode) -> bool {
+        args.sudo && matches!(mode, Mode::Install) && src.is_dir() && args.ignore.is_empty()
+    }
+
     fn apply(&self, ctx: &CommandContext) -> Result<()> {
         let src = expand_path(&self.args.src, Some(&ctx.config_dir));
         let target = expand_path(&self.args.target, Some(&ctx.config_dir));
@@ -47,6 +60,15 @@ impl CopyCommand {
             )));
         }
 
+        if Self::eligible_for_bulk(&src, &self.args, ctx.mode) {
+            ctx.log(format!(
+                "Bulk copy (sudo): {} -> {}",
+                src.display(),
+                target.display()
+            ));
+            return crate::utils::sudo::sudo_copy_tree(&src, &target);
+        }
+
         let ops = fs_ops::select(self.args.sudo);
         tree::install_tree(
             &src,
@@ -54,7 +76,8 @@ impl CopyCommand {
             &self.args.ignore,
             |dir| ops.mkdir_p(dir),
             |file, dest| copy_one(ops.as_ref(), file, dest, ctx),
-        )
+        )?;
+        ops.flush()
     }
 
     fn remove(&self, ctx: &CommandContext) -> Result<()> {
@@ -69,7 +92,8 @@ impl CopyCommand {
             } else {
                 Ok(())
             }
-        })
+        })?;
+        ops.flush()
     }
 }
 
@@ -106,9 +130,12 @@ mod tests {
         // Create dest after src so its mtime is >= src.
         std::fs::write(&dest, b"new").unwrap();
 
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (events, _rx) = crate::engine::sink::ChannelSink::channel();
         let ctx = CommandContext {
-            event_tx: tx,
+            events,
+            gate: std::sync::Arc::new(
+                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
+            ),
             mode: Mode::Install,
             config_dir: dir.path().to_path_buf(),
             temp_dir: dir.path().to_path_buf(),
@@ -130,9 +157,12 @@ mod tests {
         let dest = dir.path().join("d.txt");
         std::fs::write(&src, b"data").unwrap();
 
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (events, _rx) = crate::engine::sink::ChannelSink::channel();
         let ctx = CommandContext {
-            event_tx: tx,
+            events,
+            gate: std::sync::Arc::new(
+                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
+            ),
             mode: Mode::Install,
             config_dir: dir.path().to_path_buf(),
             temp_dir: dir.path().to_path_buf(),
@@ -147,5 +177,61 @@ mod tests {
             ops.calls(),
             vec![format!("copy_file {} {}", src.display(), dest.display())]
         );
+    }
+
+    #[test]
+    fn test_eligible_for_bulk_copy() {
+        let dir = tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let src_file = dir.path().join("f.txt");
+        std::fs::write(&src_file, b"x").unwrap();
+
+        let sudo_dir = CopyArgs {
+            src: src_dir.to_string_lossy().into(),
+            target: "/t".into(),
+            ignore: vec![],
+            sudo: true,
+        };
+        assert!(CopyCommand::eligible_for_bulk(
+            &src_dir,
+            &sudo_dir,
+            Mode::Install
+        ));
+        assert!(!CopyCommand::eligible_for_bulk(
+            &src_dir,
+            &sudo_dir,
+            Mode::Update
+        ));
+
+        let with_ignore = CopyArgs {
+            ignore: vec!["x".into()],
+            ..sudo_dir.clone()
+        };
+        assert!(!CopyCommand::eligible_for_bulk(
+            &src_dir,
+            &with_ignore,
+            Mode::Install
+        ));
+
+        let no_sudo = CopyArgs {
+            sudo: false,
+            ..sudo_dir.clone()
+        };
+        assert!(!CopyCommand::eligible_for_bulk(
+            &src_dir,
+            &no_sudo,
+            Mode::Install
+        ));
+        assert!(!CopyCommand::eligible_for_bulk(
+            &src_file,
+            &CopyArgs {
+                src: src_file.to_string_lossy().into(),
+                target: "/t".into(),
+                ignore: vec![],
+                sudo: true,
+            },
+            Mode::Install
+        ));
     }
 }

--- a/src/engine/commands/fs_ops.rs
+++ b/src/engine/commands/fs_ops.rs
@@ -38,12 +38,17 @@ pub trait FileOps: Send + Sync {
     /// Remove a symlink at `path`, handling directory symlinks on platforms
     /// (Windows) that distinguish them from file symlinks.
     fn remove_symlink(&self, path: &Path) -> Result<()>;
+
+    /// Flush any buffered work (SudoFs script batch). DirectFs is a no-op.
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Pick the adapter for a command based on whether it requested `sudo`.
 pub fn select(use_sudo: bool) -> Box<dyn FileOps> {
     if use_sudo {
-        Box::new(SudoFs)
+        Box::new(SudoFs::default())
     } else {
         Box::new(DirectFs)
     }
@@ -120,23 +125,53 @@ impl FileOps for DirectFs {
 }
 
 /// Privileged filesystem access via `sudo`.
-pub struct SudoFs;
+///
+/// Ops are buffered and applied in one `sudo bash -s` on [`FileOps::flush`]
+/// (ADR-0002). Callers that need an immediate single op can still use the
+/// helpers in [`crate::utils::sudo`] directly (e.g. bulk `cp -a`).
+pub struct SudoFs {
+    pending: std::sync::Mutex<Vec<sudo::SudoOp>>,
+}
+
+impl Default for SudoFs {
+    fn default() -> Self {
+        Self {
+            pending: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl SudoFs {
+    fn push(&self, op: sudo::SudoOp) {
+        self.pending.lock().expect("SudoFs lock").push(op);
+    }
+}
 
 impl FileOps for SudoFs {
     fn mkdir_p(&self, path: &Path) -> Result<()> {
-        sudo::sudo_mkdir(path)
+        self.push(sudo::SudoOp::Mkdir(path.to_path_buf()));
+        Ok(())
     }
 
     fn copy_file(&self, src: &Path, dest: &Path) -> Result<()> {
-        sudo::sudo_copy(src, dest)
+        self.push(sudo::SudoOp::Copy {
+            src: src.to_path_buf(),
+            dest: dest.to_path_buf(),
+        });
+        Ok(())
     }
 
     fn create_symlink(&self, src: &Path, dest: &Path) -> Result<()> {
-        sudo::sudo_symlink(src, dest)
+        self.push(sudo::SudoOp::Symlink {
+            src: src.to_path_buf(),
+            dest: dest.to_path_buf(),
+        });
+        Ok(())
     }
 
     fn remove_file(&self, path: &Path) -> Result<()> {
-        sudo::sudo_remove(path)
+        self.push(sudo::SudoOp::Remove(path.to_path_buf()));
+        Ok(())
     }
 
     fn remove_path(&self, path: &Path) -> Result<()> {
@@ -148,12 +183,23 @@ impl FileOps for SudoFs {
         {
             return self.remove_symlink(path);
         }
-        sudo::sudo_remove_dir(path)
+        self.push(sudo::SudoOp::RemoveDir(path.to_path_buf()));
+        Ok(())
     }
 
     fn remove_symlink(&self, path: &Path) -> Result<()> {
         // `rm -f` on a symlink removes the link itself, file or dir target.
-        sudo::sudo_remove(path)
+        self.push(sudo::SudoOp::Remove(path.to_path_buf()));
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<()> {
+        let ops = std::mem::take(&mut *self.pending.lock().expect("SudoFs lock"));
+        if ops.is_empty() {
+            return Ok(());
+        }
+        let script = sudo::build_sudo_script(&ops);
+        sudo::sudo_bash_script(&script)
     }
 }
 
@@ -293,10 +339,12 @@ mod tests {
     }
 
     #[test]
-    fn test_recording_fs_captures_calls() {
-        let ops = RecordingFs::default();
+    fn test_sudofs_buffers_until_flush() {
+        let ops = SudoFs::default();
         ops.mkdir_p(Path::new("/a")).unwrap();
         ops.copy_file(Path::new("/a/s"), Path::new("/a/d")).unwrap();
-        assert_eq!(ops.calls(), vec!["mkdir_p /a", "copy_file /a/s /a/d"]);
+        let pending = ops.pending.lock().unwrap().clone();
+        assert_eq!(pending.len(), 2);
+        // Do not call flush() — that would invoke real sudo.
     }
 }

--- a/src/engine/commands/mod.rs
+++ b/src/engine/commands/mod.rs
@@ -24,6 +24,13 @@ pub trait CommandExecutor: Send + Sync {
 
     /// Short description for display.
     fn description(&self) -> String;
+
+    /// Whether this Command entry holds a ConcurrencyGate permit while
+    /// `execute` runs. `machine_setup` returns false so a nested Runner can
+    /// acquire on the shared gate without deadlocking (ADR-0003).
+    fn occupies_concurrency_slot(&self) -> bool {
+        true
+    }
 }
 
 /// Create a command executor from a config entry. Takes ownership so the

--- a/src/engine/commands/setup.rs
+++ b/src/engine/commands/setup.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::sync::Arc;
 
 use crate::config::types::MachineSetupArgs;
 use crate::engine::context::CommandContext;
@@ -26,6 +27,12 @@ impl CommandExecutor for SetupCommand {
     fn description(&self) -> String {
         self.args.to_string()
     }
+
+    fn occupies_concurrency_slot(&self) -> bool {
+        // Nested Runner shares the parent gate; holding a permit here would
+        // deadlock when nested leaf commands try to acquire (ADR-0003).
+        false
+    }
 }
 
 async fn run_sub_config(args: &MachineSetupArgs, ctx: &CommandContext) -> Result<()> {
@@ -48,7 +55,8 @@ async fn run_sub_config(args: &MachineSetupArgs, ctx: &CommandContext) -> Result
     // and unresolvable paths fall back to the parent's config_dir.
     let sub_config_dir = crate::config::resolve_config_dir(&config_str, &ctx.config_dir);
 
-    let runner = crate::engine::runner::TaskRunner::new(config, ctx.mode, ctx.event_tx.clone())
+    let runner = crate::engine::runner::TaskRunner::new(config, ctx.mode, Arc::clone(&ctx.events))
+        .with_gate(Arc::clone(&ctx.gate))
         .with_config_dir(sub_config_dir)
         .with_depth(ctx.depth + 1);
 

--- a/src/engine/commands/symlink.rs
+++ b/src/engine/commands/symlink.rs
@@ -24,10 +24,17 @@ impl SymlinkCommand {
 #[async_trait]
 impl CommandExecutor for SymlinkCommand {
     async fn execute(&self, ctx: &CommandContext) -> Result<()> {
-        match ctx.mode {
-            Mode::Install | Mode::Update => self.apply(ctx),
-            Mode::Uninstall => self.remove(ctx),
-        }
+        let args = self.args.clone();
+        let ctx = ctx.clone();
+        tokio::task::spawn_blocking(move || {
+            let cmd = SymlinkCommand { args };
+            match ctx.mode {
+                Mode::Install | Mode::Update => cmd.apply(&ctx),
+                Mode::Uninstall => cmd.remove(&ctx),
+            }
+        })
+        .await
+        .map_err(|e| Error::Other(e.to_string()))?
     }
 
     fn description(&self) -> String {
@@ -55,7 +62,8 @@ impl SymlinkCommand {
             &self.args.ignore,
             |dir| tree::ensure_real_dir(ops.as_ref(), dir, |msg| ctx.log(msg)),
             |file, dest| symlink_one(ops.as_ref(), file, dest, force, ctx),
-        )
+        )?;
+        ops.flush()
     }
 
     fn remove(&self, ctx: &CommandContext) -> Result<()> {
@@ -65,7 +73,8 @@ impl SymlinkCommand {
         let ops = fs_ops::select(self.args.sudo);
         tree::uninstall_tree(&src, &target, &self.args.ignore, |dest| {
             remove_link(ops.as_ref(), dest, ctx)
-        })
+        })?;
+        ops.flush()
     }
 }
 
@@ -129,9 +138,12 @@ mod tests {
         CommandContext,
         tokio::sync::mpsc::UnboundedReceiver<crate::engine::event::TaskEvent>,
     ) {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (events, rx) = crate::engine::sink::ChannelSink::channel();
         let ctx = CommandContext {
-            event_tx: tx,
+            events,
+            gate: std::sync::Arc::new(
+                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
+            ),
             mode: Mode::Install,
             config_dir: dir.to_path_buf(),
             temp_dir: dir.to_path_buf(),

--- a/src/engine/concurrency.rs
+++ b/src/engine/concurrency.rs
@@ -1,0 +1,80 @@
+//! Concurrency gate — global cap on in-flight Task / Command executor work.
+//!
+//! See ADR-0003. Does not order Tasks by dependency (that is the Task graph).
+
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Shared limit on concurrent Task and Command executor work.
+#[derive(Clone)]
+pub struct ConcurrencyGate {
+    sem: Arc<Semaphore>,
+    /// Configured permit count (for tests / diagnostics).
+    pub limit: usize,
+}
+
+impl ConcurrencyGate {
+    /// Build a gate from `AppConfig.num_threads` (None → CPUs − 1, at least 1).
+    pub fn from_num_threads(num_threads: Option<usize>) -> Self {
+        let limit = resolve_limit(num_threads);
+        Self {
+            sem: Arc::new(Semaphore::new(limit)),
+            limit,
+        }
+    }
+
+    /// Acquire one permit; held for the lifetime of the returned guard.
+    pub async fn acquire(self: &Arc<Self>) -> OwnedSemaphorePermit {
+        self.sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("ConcurrencyGate semaphore is never closed")
+    }
+}
+
+/// Resolve `num_threads` to a positive permit count.
+///
+/// `None` → `available_parallelism() - 1` (minimum 1), matching the README default.
+pub fn resolve_limit(num_threads: Option<usize>) -> usize {
+    match num_threads {
+        Some(0) => 1,
+        Some(n) => n,
+        None => std::thread::available_parallelism()
+            .map(|n| n.get().saturating_sub(1).max(1))
+            .unwrap_or(1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_limit_respects_explicit() {
+        assert_eq!(resolve_limit(Some(4)), 4);
+        assert_eq!(resolve_limit(Some(1)), 1);
+        assert_eq!(resolve_limit(Some(0)), 1);
+    }
+
+    #[test]
+    fn resolve_limit_default_at_least_one() {
+        assert!(resolve_limit(None) >= 1);
+    }
+
+    #[tokio::test]
+    async fn gate_limits_concurrent_holders() {
+        let gate = Arc::new(ConcurrencyGate::from_num_threads(Some(1)));
+        let p1 = gate.acquire().await;
+        let gate2 = Arc::clone(&gate);
+        let handle = tokio::spawn(async move {
+            let _p2 = gate2.acquire().await;
+            true
+        });
+        tokio::task::yield_now().await;
+        assert!(!handle.is_finished());
+        drop(p1);
+        assert!(handle.await.unwrap());
+    }
+}

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -1,16 +1,21 @@
 use std::path::PathBuf;
-use tokio::sync::mpsc;
+use std::sync::Arc;
 
 use crate::config::types::Shell;
 
+use super::concurrency::ConcurrencyGate;
 use super::event::TaskEvent;
 use super::mode::Mode;
+use super::sink::{SharedSink, TaskEventSink};
 
 /// Context passed to each command during execution.
 #[derive(Clone)]
 pub struct CommandContext {
-    /// Channel for sending events to the UI/logger.
-    pub event_tx: mpsc::UnboundedSender<TaskEvent>,
+    /// Sink for Task events (lifecycle + command output).
+    pub events: SharedSink,
+
+    /// Global concurrency gate (Tasks + Command entries).
+    pub gate: Arc<ConcurrencyGate>,
 
     /// Current execution mode (install/update/uninstall).
     pub mode: Mode,
@@ -32,9 +37,14 @@ pub struct CommandContext {
 }
 
 impl CommandContext {
+    /// Emit a Task event through the sink.
+    pub fn emit(&self, event: TaskEvent) {
+        TaskEventSink::emit(self.events.as_ref(), event);
+    }
+
     /// Send a command output event.
     pub fn log(&self, line: impl Into<String>) {
-        let _ = self.event_tx.send(TaskEvent::CommandOutput {
+        self.emit(TaskEvent::CommandOutput {
             task_name: self.task_name.clone(),
             line: line.into(),
         });

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,7 @@
 pub mod commands;
+pub mod concurrency;
 pub mod context;
 pub mod event;
 pub mod mode;
 pub mod runner;
+pub mod sink;

--- a/src/engine/runner.rs
+++ b/src/engine/runner.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use tokio::sync::mpsc;
+use std::sync::Arc;
 
 use crate::config::graph::TaskGraph;
 use crate::config::history::History;
@@ -8,14 +8,17 @@ use crate::error::{Error, Result};
 use crate::utils::path::expand_path;
 
 use super::commands::{create_executor, CommandExecutor};
+use super::concurrency::ConcurrencyGate;
 use super::context::CommandContext;
 use super::event::TaskEvent;
 use super::mode::Mode;
+use super::sink::{SharedSink, TaskEventSink};
 
 pub struct TaskRunner {
     config: AppConfig,
     mode: Mode,
-    event_tx: mpsc::UnboundedSender<TaskEvent>,
+    events: SharedSink,
+    gate: Arc<ConcurrencyGate>,
     config_dir: PathBuf,
     depth: usize,
 }
@@ -29,14 +32,22 @@ struct Tally {
 }
 
 impl TaskRunner {
-    pub fn new(config: AppConfig, mode: Mode, event_tx: mpsc::UnboundedSender<TaskEvent>) -> Self {
+    pub fn new(config: AppConfig, mode: Mode, events: SharedSink) -> Self {
+        let gate = Arc::new(ConcurrencyGate::from_num_threads(config.num_threads));
         Self {
             config,
             mode,
-            event_tx,
+            events,
+            gate,
             config_dir: std::env::current_dir().unwrap_or_default(),
             depth: 0,
         }
+    }
+
+    /// Override the concurrency gate (e.g. nested Sub-config sharing the parent).
+    pub fn with_gate(mut self, gate: Arc<ConcurrencyGate>) -> Self {
+        self.gate = gate;
+        self
     }
 
     pub fn with_config_dir(mut self, dir: PathBuf) -> Self {
@@ -111,6 +122,10 @@ impl TaskRunner {
     /// then join — recording each task's outcome into `tally` and history. A
     /// layer of one task (sequential mode) runs that task to completion before
     /// the caller advances to the next layer.
+    ///
+    /// ConcurrencyGate permits are acquired per Command entry inside
+    /// [`run_task`] (not per Task), so nested Sub-configs can share the gate
+    /// without deadlocking (ADR-0003).
     async fn run_layer(
         &self,
         layer: &[String],
@@ -213,7 +228,8 @@ impl TaskRunner {
 
     fn create_context(&self, task_name: &str, temp_dir: &Path) -> CommandContext {
         CommandContext {
-            event_tx: self.event_tx.clone(),
+            events: Arc::clone(&self.events),
+            gate: Arc::clone(&self.gate),
             mode: self.mode,
             config_dir: self.config_dir.clone(),
             temp_dir: temp_dir.to_path_buf(),
@@ -232,7 +248,7 @@ impl TaskRunner {
     }
 
     fn send(&self, event: TaskEvent) {
-        let _ = self.event_tx.send(event);
+        TaskEventSink::emit(self.events.as_ref(), event);
     }
 }
 
@@ -244,7 +260,7 @@ async fn run_task_with_retry(name: &str, task: &TaskConfig, ctx: &CommandContext
         match run_task(name, task, ctx).await {
             Ok(()) => return Ok(()),
             Err(e) if attempt < max_attempts => {
-                let _ = ctx.event_tx.send(TaskEvent::TaskRetry {
+                ctx.emit(TaskEvent::TaskRetry {
                     task_name: name.to_string(),
                     attempt,
                     max_attempts,
@@ -260,7 +276,7 @@ async fn run_task_with_retry(name: &str, task: &TaskConfig, ctx: &CommandContext
 }
 
 async fn run_task(name: &str, task: &TaskConfig, ctx: &CommandContext) -> Result<()> {
-    let _ = ctx.event_tx.send(TaskEvent::TaskStarted {
+    ctx.emit(TaskEvent::TaskStarted {
         task_name: name.to_string(),
         command_count: task.commands.len(),
         depth: ctx.depth,
@@ -270,35 +286,35 @@ async fn run_task(name: &str, task: &TaskConfig, ctx: &CommandContext) -> Result
         task.commands.iter().cloned().map(create_executor).collect();
 
     if task.parallel {
-        // Run commands in parallel
         let mut handles = Vec::new();
 
         for executor in executors {
             let ctx = ctx.clone();
-            handles.push(tokio::spawn(async move { executor.execute(&ctx).await }));
+            handles.push(tokio::spawn(async move {
+                execute_with_gate(executor.as_ref(), &ctx).await
+            }));
         }
 
         for handle in handles {
             handle.await.map_err(|e| Error::Other(e.to_string()))??;
         }
     } else {
-        // Run commands sequentially
         for executor in &executors {
             let desc = executor.description();
-            let _ = ctx.event_tx.send(TaskEvent::CommandStarted {
+            ctx.emit(TaskEvent::CommandStarted {
                 task_name: name.to_string(),
                 command_desc: desc.clone(),
             });
 
-            match executor.execute(ctx).await {
+            match execute_with_gate(executor.as_ref(), ctx).await {
                 Ok(()) => {
-                    let _ = ctx.event_tx.send(TaskEvent::CommandCompleted {
+                    ctx.emit(TaskEvent::CommandCompleted {
                         task_name: name.to_string(),
                         command_desc: desc,
                     });
                 }
                 Err(e) => {
-                    let _ = ctx.event_tx.send(TaskEvent::CommandFailed {
+                    ctx.emit(TaskEvent::CommandFailed {
                         task_name: name.to_string(),
                         command_desc: desc,
                         error: e.to_string(),
@@ -309,9 +325,20 @@ async fn run_task(name: &str, task: &TaskConfig, ctx: &CommandContext) -> Result
         }
     }
 
-    let _ = ctx.event_tx.send(TaskEvent::TaskCompleted {
+    ctx.emit(TaskEvent::TaskCompleted {
         task_name: name.to_string(),
     });
 
     Ok(())
+}
+
+/// Acquire a ConcurrencyGate permit for leaf Command entries only.
+async fn execute_with_gate(executor: &dyn CommandExecutor, ctx: &CommandContext) -> Result<()> {
+    if executor.occupies_concurrency_slot() {
+        let permit = ctx.gate.acquire().await;
+        let _permit = permit;
+        executor.execute(ctx).await
+    } else {
+        executor.execute(ctx).await
+    }
 }

--- a/src/engine/sink.rs
+++ b/src/engine/sink.rs
@@ -1,0 +1,80 @@
+//! Task event sink — the seam for emitting progress events.
+//!
+//! Adapters: [`ChannelSink`] (mpsc → TUI/plain) and [`NullSink`] (Command bench).
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use super::event::TaskEvent;
+
+/// Emit Task events without callers knowing about channels or UI.
+pub trait TaskEventSink: Send + Sync {
+    fn emit(&self, event: TaskEvent);
+}
+
+/// Shared handle used by the Runner and CommandContext.
+pub type SharedSink = Arc<dyn TaskEventSink>;
+
+/// Forwards events onto an unbounded mpsc channel (TUI / plain logger).
+pub struct ChannelSink {
+    tx: mpsc::UnboundedSender<TaskEvent>,
+}
+
+impl ChannelSink {
+    pub fn from_sender(tx: mpsc::UnboundedSender<TaskEvent>) -> SharedSink {
+        Arc::new(Self { tx })
+    }
+
+    /// Create a channel pair wrapped as a sink + receiver.
+    pub fn channel() -> (SharedSink, mpsc::UnboundedReceiver<TaskEvent>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self::from_sender(tx), rx)
+    }
+}
+
+impl TaskEventSink for ChannelSink {
+    fn emit(&self, event: TaskEvent) {
+        let _ = self.tx.send(event);
+    }
+}
+
+/// Discards all events — used by Command bench Runner smoke.
+pub struct NullSink;
+
+impl NullSink {
+    pub fn shared() -> SharedSink {
+        Arc::new(Self)
+    }
+}
+
+impl TaskEventSink for NullSink {
+    fn emit(&self, _event: TaskEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_sink_delivers_events() {
+        let (sink, mut rx) = ChannelSink::channel();
+        sink.emit(TaskEvent::TaskCompleted {
+            task_name: "t".into(),
+        });
+        match rx.try_recv() {
+            Ok(TaskEvent::TaskCompleted { task_name }) => assert_eq!(task_name, "t"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn null_sink_drops_events() {
+        let sink = NullSink::shared();
+        sink.emit(TaskEvent::AllDone {
+            succeeded: 1,
+            failed: 0,
+            skipped: 0,
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,9 @@ use machine_setup::{cli, config, engine, error, tui};
 
 use clap::{CommandFactory, Parser};
 use std::io::IsTerminal;
-use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use cli::{Cli, Command};
-use engine::event::TaskEvent;
 use engine::mode::Mode;
 use engine::runner::TaskRunner;
 
@@ -74,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
     let config_dir = config::resolve_config_dir(&cli.config, &cwd);
 
     // Create event channel and cancellation token
-    let (event_tx, event_rx) = mpsc::unbounded_channel::<TaskEvent>();
+    let (events, event_rx) = engine::sink::ChannelSink::channel();
     let cancel = CancellationToken::new();
 
     // Determine if we should use the TUI
@@ -91,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
         .expect("list/validate/completions are handled before this point");
 
     // Set up runner (moves app_config)
-    let runner = TaskRunner::new(app_config, mode, event_tx).with_config_dir(config_dir);
+    let runner = TaskRunner::new(app_config, mode, events).with_config_dir(config_dir);
     let force = cli.force;
     let task_names_clone = task_names.clone();
 

--- a/src/utils/sudo.rs
+++ b/src/utils/sudo.rs
@@ -1,10 +1,18 @@
 use crate::error::{Error, Result};
-use std::path::Path;
-use std::process::Command;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// Copy a file using `sudo cp`.
 pub fn sudo_copy(src: &Path, dest: &Path) -> Result<()> {
     run_sudo(&["cp", "-f", &src.to_string_lossy(), &dest.to_string_lossy()])
+}
+
+/// Copy a directory tree into `target` with one `sudo cp -a` (contents of `src`).
+pub fn sudo_copy_tree(src: &Path, target: &Path) -> Result<()> {
+    sudo_mkdir(target)?;
+    let src_contents = format!("{}/.", src.to_string_lossy());
+    run_sudo(&["cp", "-a", &src_contents, &target.to_string_lossy()])
 }
 
 /// Create a symlink using `sudo ln -sf`.
@@ -27,6 +35,78 @@ pub fn sudo_mkdir(path: &Path) -> Result<()> {
     run_sudo(&["mkdir", "-p", &path.to_string_lossy()])
 }
 
+/// One buffered privileged filesystem operation (SudoFs script batch).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SudoOp {
+    Mkdir(PathBuf),
+    Copy { src: PathBuf, dest: PathBuf },
+    Symlink { src: PathBuf, dest: PathBuf },
+    Remove(PathBuf),
+    RemoveDir(PathBuf),
+}
+
+/// Shell-escape a path for single-quoted use in a bash script.
+pub fn sh_quote(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// Render buffered ops as a bash script (one sudo process via [`sudo_bash_script`]).
+pub fn build_sudo_script(ops: &[SudoOp]) -> String {
+    let mut script = String::from("set -euo pipefail\n");
+    for op in ops {
+        match op {
+            SudoOp::Mkdir(path) => {
+                script.push_str(&format!("mkdir -p {}\n", sh_quote(path)));
+            }
+            SudoOp::Copy { src, dest } => {
+                script.push_str(&format!("cp -f {} {}\n", sh_quote(src), sh_quote(dest)));
+            }
+            SudoOp::Symlink { src, dest } => {
+                script.push_str(&format!("ln -sf {} {}\n", sh_quote(src), sh_quote(dest)));
+            }
+            SudoOp::Remove(path) => {
+                script.push_str(&format!("rm -f {}\n", sh_quote(path)));
+            }
+            SudoOp::RemoveDir(path) => {
+                script.push_str(&format!("rm -rf {}\n", sh_quote(path)));
+            }
+        }
+    }
+    script
+}
+
+/// Run a bash script under a single `sudo bash -s`.
+pub fn sudo_bash_script(script: &str) -> Result<()> {
+    let mut child = Command::new("sudo")
+        .args(["bash", "-s"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| Error::Other(format!("Failed to run sudo bash: {e}")))?;
+
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| Error::Other("Failed to open sudo bash stdin".into()))?;
+        stdin
+            .write_all(script.as_bytes())
+            .map_err(|e| Error::Other(format!("Failed to write sudo script: {e}")))?;
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| Error::Other(format!("Failed to wait for sudo bash: {e}")))?;
+
+    if !status.success() {
+        return Err(Error::Other(format!(
+            "sudo bash script failed with exit code {}",
+            status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(())
+}
+
 fn run_sudo(args: &[&str]) -> Result<()> {
     let status = Command::new("sudo")
         .args(args)
@@ -42,4 +122,37 @@ fn run_sudo(args: &[&str]) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sh_quote_escapes_single_quotes() {
+        assert_eq!(sh_quote(Path::new("a'b")), r"'a'\''b'");
+    }
+
+    #[test]
+    fn build_sudo_script_orders_ops() {
+        let script = build_sudo_script(&[
+            SudoOp::Mkdir(PathBuf::from("/t")),
+            SudoOp::Copy {
+                src: PathBuf::from("/s/f"),
+                dest: PathBuf::from("/t/f"),
+            },
+            SudoOp::Symlink {
+                src: PathBuf::from("/s/l"),
+                dest: PathBuf::from("/t/l"),
+            },
+            SudoOp::Remove(PathBuf::from("/t/old")),
+            SudoOp::RemoveDir(PathBuf::from("/t/dir")),
+        ]);
+        assert!(script.contains("mkdir -p '/t'\n"));
+        assert!(script.contains("cp -f '/s/f' '/t/f'\n"));
+        assert!(script.contains("ln -sf '/s/l' '/t/l'\n"));
+        assert!(script.contains("rm -f '/t/old'\n"));
+        assert!(script.contains("rm -rf '/t/dir'\n"));
+        assert!(script.starts_with("set -euo pipefail\n"));
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use tempfile::tempdir;
-use tokio::sync::mpsc;
 
 use machine_setup::config;
 use machine_setup::engine::event::TaskEvent;
@@ -17,9 +16,9 @@ async fn run_config(yaml: &str, mode: Mode) -> Vec<TaskEvent> {
     // Use test-local temp_dir so history doesn't leak between tests
     config.temp_dir = dir.path().join(".ms_temp").to_string_lossy().to_string();
 
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
 
-    let runner = TaskRunner::new(config, mode, tx).with_config_dir(dir.path().to_path_buf());
+    let runner = TaskRunner::new(config, mode, events).with_config_dir(dir.path().to_path_buf());
 
     let _ = runner.run_all(true).await;
 
@@ -281,9 +280,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     // Verify file was copied
@@ -324,9 +323,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     assert!(target_dir.join("keep.txt").exists());
@@ -362,9 +361,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let link = target_dir.join("dotfile");
@@ -416,9 +415,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let dest_pack = target_skills.join("route-agents");
@@ -486,9 +485,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let dest_pack = target_skills.join("route-agents");
@@ -537,16 +536,16 @@ tasks:
 
     // First run
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx1, _rx1) = mpsc::unbounded_channel();
+    let (events1, _rx1) = machine_setup::engine::sink::ChannelSink::channel();
     let runner1 =
-        TaskRunner::new(config, Mode::Install, tx1).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events1).with_config_dir(dir.path().to_path_buf());
     let _ = runner1.run_all(false).await;
 
     // Second run (should skip)
     let config2 = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx2, mut rx2) = mpsc::unbounded_channel();
+    let (events2, mut rx2) = machine_setup::engine::sink::ChannelSink::channel();
     let runner2 =
-        TaskRunner::new(config2, Mode::Install, tx2).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config2, Mode::Install, events2).with_config_dir(dir.path().to_path_buf());
     let _ = runner2.run_all(false).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -579,16 +578,16 @@ tasks:
 
     // First run
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx1, _rx1) = mpsc::unbounded_channel();
+    let (events1, _rx1) = machine_setup::engine::sink::ChannelSink::channel();
     let runner1 =
-        TaskRunner::new(config, Mode::Install, tx1).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events1).with_config_dir(dir.path().to_path_buf());
     let _ = runner1.run_all(false).await;
 
     // Second run with force
     let config2 = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx2, mut rx2) = mpsc::unbounded_channel();
+    let (events2, mut rx2) = machine_setup::engine::sink::ChannelSink::channel();
     let runner2 =
-        TaskRunner::new(config2, Mode::Install, tx2).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config2, Mode::Install, events2).with_config_dir(dir.path().to_path_buf());
     let _ = runner2.run_all(true).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -625,6 +624,34 @@ tasks:
 
     assert!(task_completed(&events, "a"));
     assert!(task_completed(&events, "b"));
+}
+
+#[tokio::test]
+async fn test_num_threads_one_still_runs_parallel_tasks() {
+    // Concurrency gate with limit 1 must serialize Tasks but still complete.
+    let events = run_config(
+        r#"
+default_shell: bash
+parallel: true
+num_threads: 1
+tasks:
+  a:
+    commands:
+      - run:
+          commands: "echo a-done"
+  b:
+    commands:
+      - run:
+          commands: "echo b-done"
+"#,
+        Mode::Install,
+    )
+    .await;
+
+    assert!(task_completed(&events, "a"));
+    assert!(task_completed(&events, "b"));
+    assert!(find_output(&events, "a", "a-done"));
+    assert!(find_output(&events, "b", "b-done"));
 }
 
 #[tokio::test]
@@ -683,9 +710,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let mut events = Vec::new();
@@ -694,6 +721,57 @@ tasks:
     }
 
     assert!(find_output(&events, "sub_task", "from_sub_config"));
+}
+
+#[tokio::test]
+async fn test_nested_sub_config_with_num_threads_one() {
+    // Regression: shared ConcurrencyGate must not deadlock when the parent
+    // machine_setup command would otherwise hold the only permit.
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("sub.yaml"),
+        r#"
+tasks:
+  nested:
+    commands:
+      - run:
+          commands: "echo nested-ok"
+"#,
+    )
+    .unwrap();
+
+    let config_path = dir.path().join("config.yaml");
+    fs::write(
+        &config_path,
+        r#"
+default_shell: bash
+num_threads: 1
+tasks:
+  parent:
+    commands:
+      - machine_setup:
+          config: "./sub.yaml"
+"#,
+    )
+    .unwrap();
+
+    let config = config::load_config(config_path.to_str().unwrap()).unwrap();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
+    let runner =
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
+
+    let run = tokio::time::timeout(std::time::Duration::from_secs(5), runner.run_all(true)).await;
+    assert!(
+        run.is_ok(),
+        "nested sub-config deadlocked under num_threads: 1"
+    );
+    assert!(run.unwrap().is_ok());
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    assert!(find_output(&events, "nested", "nested-ok"));
 }
 
 // ─── Config format tests ───
@@ -709,9 +787,9 @@ async fn test_json_config() {
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let mut events = Vec::new();
@@ -744,9 +822,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     let mut events = Vec::new();
@@ -839,9 +917,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -897,9 +975,9 @@ tasks:
     .unwrap();
 
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1101,9 +1179,9 @@ tasks:
     let mut config = config::load_config(config_path.to_str().unwrap()).unwrap();
     config.temp_dir = dir.path().join(".ms_temp").to_string_lossy().to_string();
 
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (events, mut rx) = machine_setup::engine::sink::ChannelSink::channel();
     let runner =
-        TaskRunner::new(config, Mode::Install, tx).with_config_dir(dir.path().to_path_buf());
+        TaskRunner::new(config, Mode::Install, events).with_config_dir(dir.path().to_path_buf());
     let _ = runner.run_all(true).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1168,8 +1246,8 @@ tasks:
 /// Run a config at `config_path` once in the given mode, against `base_dir`.
 async fn run_at(config_path: &std::path::Path, base_dir: &std::path::Path, mode: Mode) {
     let config = config::load_config(config_path.to_str().unwrap()).unwrap();
-    let (tx, _rx) = mpsc::unbounded_channel();
-    let runner = TaskRunner::new(config, mode, tx).with_config_dir(base_dir.to_path_buf());
+    let (events, _rx) = machine_setup::engine::sink::ChannelSink::channel();
+    let runner = TaskRunner::new(config, mode, events).with_config_dir(base_dir.to_path_buf());
     let _ = runner.run_all(true).await;
 }
 


### PR DESCRIPTION
## Summary
- Add Task event sink (`ChannelSink` / `NullSink`) and Criterion Command bench suite for before/after measurement
- Wire Concurrency gate from `num_threads` (per Command entry; `machine_setup` does not hold a slot so nested Sub-configs cannot deadlock at limit 1)
- Deepen SudoFs: script-batch + flush; eligible Install dir copy uses bulk `sudo cp -a`
- Record ADRs 0001–0005 and update CONTEXT.md

## Test plan
- [x] `make lint` / `make test`
- [x] `cargo bench --bench command_bench -- --test`
- [x] Integration: `test_nested_sub_config_with_num_threads_one`
- [x] Optional: `MACHINE_SETUP_BENCH_SUDO=1 make bench` on a passwordless-sudo host