### PR TITLE
perf: parallelize DirectFs tree apply on the concurrency gate pool

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,8 +90,8 @@ _Avoid_: fs helper, file utils.
 **Tree materialization**:
 The shared traversal behind `copy` and `symlink`: destination resolution (the
 file-vs-directory target rule) plus the install/uninstall walk, parameterized by
-a per-file operation. In-tree parallel file apply is deferred until Command
-bench numbers show DirectFs walk/apply as the next cliff.
+a per-file operation. Directory installs mkdir sequentially, then apply files on
+the Concurrency gate's shared Rayon pool (ADR-0004).
 _Avoid_: file walker, copier.
 
 **Command bench**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "dirs",
  "indexmap",
  "ratatui",
+ "rayon",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ async-trait = "0.1"
 tokio-util = "0.7"
 indexmap = { version = "2", features = ["serde"] }
 ureq = "3"
+rayon = "1"
 
 [build-dependencies]
 winresource = "0.1"

--- a/benches/command_bench.rs
+++ b/benches/command_bench.rs
@@ -9,11 +9,15 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rayon::ThreadPool;
 use tempfile::TempDir;
 
 use machine_setup::config;
 use machine_setup::engine::commands::fs_ops::{self, DirectFs, FileOps};
-use machine_setup::engine::commands::tree::{self, install_tree, uninstall_tree};
+use machine_setup::engine::commands::tree::{
+    self, install_tree_with_pool, uninstall_tree_with_pool,
+};
+use machine_setup::engine::concurrency::resolve_limit;
 use machine_setup::engine::mode::Mode;
 use machine_setup::engine::runner::TaskRunner;
 use machine_setup::engine::sink::NullSink;
@@ -53,15 +57,26 @@ fn fixture_1k() -> &'static TreeFixture {
     FIXTURE.get_or_init(|| TreeFixture::generate(N_FILES))
 }
 
+fn bench_pool() -> &'static ThreadPool {
+    static POOL: OnceLock<ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(resolve_limit(None))
+            .build()
+            .expect("bench pool")
+    })
+}
+
 fn sudo_enabled() -> bool {
     std::env::var_os("MACHINE_SETUP_BENCH_SUDO").is_some_and(|v| v != "0")
 }
 
 fn copy_tree(ops: &dyn FileOps, src: &Path, dest: &Path) {
-    install_tree(
+    install_tree_with_pool(
         src,
         dest,
         &[],
+        Some(bench_pool()),
         |dir| ops.mkdir_p(dir),
         |file, dest| ops.copy_file(file, dest),
     )
@@ -69,10 +84,12 @@ fn copy_tree(ops: &dyn FileOps, src: &Path, dest: &Path) {
 }
 
 fn link_tree(ops: &dyn FileOps, src: &Path, dest: &Path) {
-    install_tree(
+    // Symlink create is cheap; keep sequential (matches production SymlinkCommand).
+    install_tree_with_pool(
         src,
         dest,
         &[],
+        None,
         |dir| tree::ensure_real_dir(ops, dir, |_| {}),
         |file, dest| ops.create_symlink(file, dest),
     )
@@ -130,10 +147,11 @@ fn bench_mtime_skip(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(3));
     group.bench_function("1k_already_synced", |b| {
         b.iter(|| {
-            install_tree(
+            install_tree_with_pool(
                 fixture.src(),
                 synced.path(),
                 &[],
+                Some(bench_pool()),
                 |dir| ops.mkdir_p(dir),
                 |src, dest| {
                     if dest.exists() {
@@ -186,12 +204,18 @@ fn bench_uninstall_tree(c: &mut Criterion) {
                 dest
             },
             |dest| {
-                uninstall_tree(fixture.src(), dest.path(), &[], |path| {
-                    if path.exists() {
-                        ops.remove_file(path)?;
-                    }
-                    Ok(())
-                })
+                uninstall_tree_with_pool(
+                    fixture.src(),
+                    dest.path(),
+                    &[],
+                    Some(bench_pool()),
+                    |path| {
+                        if path.exists() {
+                            ops.remove_file(path)?;
+                        }
+                        Ok(())
+                    },
+                )
                 .expect("uninstall_tree");
             },
             BatchSize::LargeInput,

--- a/docs/adr/0003-concurrency-gate-global.md
+++ b/docs/adr/0003-concurrency-gate-global.md
@@ -8,5 +8,6 @@ Sub-config Runners share the parent's gate and their leaf commands acquire
 normally. That avoids a deadlock when `num_threads: 1` and a parent Task would
 otherwise hold the only permit across nested work. Sync File ops (`copy` /
 `symlink`) run via `spawn_blocking`. We accepted that a fat `parallel: true`
-Task can starve siblings; per-Task sub-quotas are a future fix. A dedicated FS
-thread pool waits until in-tree parallel apply needs it.
+Task can starve siblings; per-Task sub-quotas are a future fix. The gate also
+owns a shared Rayon pool of the same size for in-tree DirectFs file apply
+(ADR-0004) so sibling commands do not each spawn a private worker set.

--- a/docs/adr/0004-defer-parallel-tree-materialization.md
+++ b/docs/adr/0004-defer-parallel-tree-materialization.md
@@ -1,7 +1,9 @@
-# Defer parallel file apply inside Tree materialization
+# Parallel file apply inside Tree materialization
 
-In-tree concurrent `on_file` for DirectFs is deferred until Command bench
-baselines show sequential walk/apply as the next cliff after SudoFs hybrid and
-the Concurrency gate. Keep the `install_tree` / `uninstall_tree` interface;
-parallelism would be implementation-only. Do not introduce a second concurrency
-knob independent of `num_threads`.
+Directory installs create parents sequentially (WalkDir order), then apply
+collected files on the **shared** Rayon pool owned by the Concurrency gate
+(sized by `num_threads`, default: physical CPUs − 1). Sibling Command entries
+share that pool so `parallel: true` tasks do not oversubscribe. Threshold:
+fewer than 32 files stay sequential. SudoFs walks stay single-threaded (script
+batch on flush). Symlink stays sequential (metadata-cheap). No second
+concurrency knob.

--- a/src/engine/commands/copy.rs
+++ b/src/engine/commands/copy.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::utils::path::expand_path;
 
 use super::fs_ops::{self, FileOps};
+use super::progress_log::FileProgress;
 use super::tree;
 use super::CommandExecutor;
 
@@ -45,7 +46,11 @@ impl CommandExecutor for CopyCommand {
 impl CopyCommand {
     /// Directory Install with empty ignore → one `sudo cp -a` (ADR-0002).
     /// Update keeps mtime-skip via per-file + script batch.
-    fn eligible_for_bulk(src: &Path, args: &CopyArgs, mode: Mode) -> bool {
+    ///
+    /// Non-sudo Install uses parallel DirectFs apply (ADR-0004) instead of a
+    /// bulk `cp -a`: Command bench on WSL showed process-spawned `cp` slower
+    /// than in-process parallel `std::fs::copy` for typical tree sizes.
+    fn eligible_for_bulk_sudo(src: &Path, args: &CopyArgs, mode: Mode) -> bool {
         args.sudo && matches!(mode, Mode::Install) && src.is_dir() && args.ignore.is_empty()
     }
 
@@ -60,7 +65,7 @@ impl CopyCommand {
             )));
         }
 
-        if Self::eligible_for_bulk(&src, &self.args, ctx.mode) {
+        if Self::eligible_for_bulk_sudo(&src, &self.args, ctx.mode) {
             ctx.log(format!(
                 "Bulk copy (sudo): {} -> {}",
                 src.display(),
@@ -70,13 +75,22 @@ impl CopyCommand {
         }
 
         let ops = fs_ops::select(self.args.sudo);
-        tree::install_tree(
+        let progress = FileProgress::new(ctx, "copy");
+        // SudoFs only buffers; DirectFs uses the shared gate pool (ADR-0004).
+        let pool = if self.args.sudo {
+            None
+        } else {
+            Some(ctx.gate.pool())
+        };
+        tree::install_tree_with_pool(
             &src,
             &target,
             &self.args.ignore,
+            pool,
             |dir| ops.mkdir_p(dir),
-            |file, dest| copy_one(ops.as_ref(), file, dest, ctx),
+            |file, dest| copy_one(ops.as_ref(), file, dest, &progress),
         )?;
+        progress.finish();
         ops.flush()
     }
 
@@ -85,33 +99,40 @@ impl CopyCommand {
         let target = expand_path(&self.args.target, Some(&ctx.config_dir));
 
         let ops = fs_ops::select(self.args.sudo);
-        tree::uninstall_tree(&src, &target, &self.args.ignore, |dest| {
+        let progress = FileProgress::new(ctx, "copy remove");
+        let pool = if self.args.sudo {
+            None
+        } else {
+            Some(ctx.gate.pool())
+        };
+        tree::uninstall_tree_with_pool(&src, &target, &self.args.ignore, pool, |dest| {
             if dest.exists() {
-                ctx.log(format!("Removing: {}", dest.display()));
+                progress.note_apply(|| format!("Removing: {}", dest.display()));
                 ops.remove_file(dest)
             } else {
                 Ok(())
             }
         })?;
+        progress.finish();
         ops.flush()
     }
 }
 
 /// Copy a single file, skipping when the destination is already at least as
 /// new as the source.
-fn copy_one(ops: &dyn FileOps, src: &Path, dest: &Path, ctx: &CommandContext) -> Result<()> {
+fn copy_one(ops: &dyn FileOps, src: &Path, dest: &Path, progress: &FileProgress<'_>) -> Result<()> {
     if dest.exists() {
         if let (Ok(src_meta), Ok(dest_meta)) = (std::fs::metadata(src), std::fs::metadata(dest)) {
             if let (Ok(src_mod), Ok(dest_mod)) = (src_meta.modified(), dest_meta.modified()) {
                 if dest_mod >= src_mod {
-                    ctx.log(format!("Skipping (target newer): {}", dest.display()));
+                    progress.note_skip(|| format!("Skipping (target newer): {}", dest.display()));
                     return Ok(());
                 }
             }
         }
     }
 
-    ctx.log(format!("Copying: {} -> {}", src.display(), dest.display()));
+    progress.note_apply(|| format!("Copying: {} -> {}", src.display(), dest.display()));
     ops.copy_file(src, dest)
 }
 
@@ -120,6 +141,22 @@ mod tests {
     use super::*;
     use crate::engine::commands::fs_ops::RecordingFs;
     use tempfile::tempdir;
+
+    fn ctx_for(dir: &Path) -> CommandContext {
+        let (events, _rx) = crate::engine::sink::ChannelSink::channel();
+        CommandContext {
+            events,
+            gate: std::sync::Arc::new(
+                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
+            ),
+            mode: Mode::Install,
+            config_dir: dir.to_path_buf(),
+            temp_dir: dir.to_path_buf(),
+            default_shell: crate::config::types::Shell::Bash,
+            task_name: "t".to_string(),
+            depth: 0,
+        }
+    }
 
     #[test]
     fn test_copy_one_skips_when_dest_newer() {
@@ -130,22 +167,10 @@ mod tests {
         // Create dest after src so its mtime is >= src.
         std::fs::write(&dest, b"new").unwrap();
 
-        let (events, _rx) = crate::engine::sink::ChannelSink::channel();
-        let ctx = CommandContext {
-            events,
-            gate: std::sync::Arc::new(
-                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
-            ),
-            mode: Mode::Install,
-            config_dir: dir.path().to_path_buf(),
-            temp_dir: dir.path().to_path_buf(),
-            default_shell: crate::config::types::Shell::Bash,
-            task_name: "t".to_string(),
-            depth: 0,
-        };
-
+        let ctx = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "copy");
         let ops = RecordingFs::default();
-        copy_one(&ops, &src, &dest, &ctx).unwrap();
+        copy_one(&ops, &src, &dest, &progress).unwrap();
         // Skipped: no copy_file recorded.
         assert!(ops.calls().is_empty());
     }
@@ -157,22 +182,10 @@ mod tests {
         let dest = dir.path().join("d.txt");
         std::fs::write(&src, b"data").unwrap();
 
-        let (events, _rx) = crate::engine::sink::ChannelSink::channel();
-        let ctx = CommandContext {
-            events,
-            gate: std::sync::Arc::new(
-                crate::engine::concurrency::ConcurrencyGate::from_num_threads(Some(1)),
-            ),
-            mode: Mode::Install,
-            config_dir: dir.path().to_path_buf(),
-            temp_dir: dir.path().to_path_buf(),
-            default_shell: crate::config::types::Shell::Bash,
-            task_name: "t".to_string(),
-            depth: 0,
-        };
-
+        let ctx = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "copy");
         let ops = RecordingFs::default();
-        copy_one(&ops, &src, &dest, &ctx).unwrap();
+        copy_one(&ops, &src, &dest, &progress).unwrap();
         assert_eq!(
             ops.calls(),
             vec![format!("copy_file {} {}", src.display(), dest.display())]
@@ -180,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eligible_for_bulk_copy() {
+    fn test_eligible_for_bulk_sudo() {
         let dir = tempdir().unwrap();
         let src_dir = dir.path().join("src");
         std::fs::create_dir_all(&src_dir).unwrap();
@@ -193,12 +206,12 @@ mod tests {
             ignore: vec![],
             sudo: true,
         };
-        assert!(CopyCommand::eligible_for_bulk(
+        assert!(CopyCommand::eligible_for_bulk_sudo(
             &src_dir,
             &sudo_dir,
             Mode::Install
         ));
-        assert!(!CopyCommand::eligible_for_bulk(
+        assert!(!CopyCommand::eligible_for_bulk_sudo(
             &src_dir,
             &sudo_dir,
             Mode::Update
@@ -208,7 +221,7 @@ mod tests {
             ignore: vec!["x".into()],
             ..sudo_dir.clone()
         };
-        assert!(!CopyCommand::eligible_for_bulk(
+        assert!(!CopyCommand::eligible_for_bulk_sudo(
             &src_dir,
             &with_ignore,
             Mode::Install
@@ -218,12 +231,12 @@ mod tests {
             sudo: false,
             ..sudo_dir.clone()
         };
-        assert!(!CopyCommand::eligible_for_bulk(
+        assert!(!CopyCommand::eligible_for_bulk_sudo(
             &src_dir,
             &no_sudo,
             Mode::Install
         ));
-        assert!(!CopyCommand::eligible_for_bulk(
+        assert!(!CopyCommand::eligible_for_bulk_sudo(
             &src_file,
             &CopyArgs {
                 src: src_file.to_string_lossy().into(),

--- a/src/engine/commands/fs_ops.rs
+++ b/src/engine/commands/fs_ops.rs
@@ -64,8 +64,11 @@ impl FileOps for DirectFs {
     }
 
     fn copy_file(&self, src: &Path, dest: &Path) -> Result<()> {
+        // Tree materialization already ensures parents; only create when missing.
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)?;
+            if !parent.is_dir() {
+                std::fs::create_dir_all(parent)?;
+            }
         }
         std::fs::copy(src, dest)?;
         Ok(())

--- a/src/engine/commands/mod.rs
+++ b/src/engine/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod clone;
 pub mod copy;
 pub mod fs_ops;
+pub mod progress_log;
 pub mod run;
 pub mod setup;
 pub mod symlink;

--- a/src/engine/commands/progress_log.rs
+++ b/src/engine/commands/progress_log.rs
@@ -1,0 +1,75 @@
+//! Coalesced per-file progress logs for large tree materialization.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::engine::context::CommandContext;
+
+/// Log the first few file ops in full, then periodically, then a summary.
+const DETAIL: usize = 5;
+const EVERY: usize = 100;
+
+/// Thread-safe progress logger for copy/symlink tree walks.
+pub struct FileProgress<'a> {
+    ctx: &'a CommandContext,
+    label: &'static str,
+    applied: AtomicUsize,
+    skipped: AtomicUsize,
+}
+
+impl<'a> FileProgress<'a> {
+    pub fn new(ctx: &'a CommandContext, label: &'static str) -> Self {
+        Self {
+            ctx,
+            label,
+            applied: AtomicUsize::new(0),
+            skipped: AtomicUsize::new(0),
+        }
+    }
+
+    /// Record an applied file op; may emit a detail or periodic log line.
+    pub fn note_apply(&self, line: impl FnOnce() -> String) {
+        let n = self.applied.fetch_add(1, Ordering::Relaxed) + 1;
+        if should_log_detail(n) {
+            self.ctx.log(line());
+        }
+    }
+
+    /// Record a skipped file; may emit a detail or periodic log line.
+    pub fn note_skip(&self, line: impl FnOnce() -> String) {
+        let n = self.skipped.fetch_add(1, Ordering::Relaxed) + 1;
+        if should_log_detail(n) {
+            self.ctx.log(line());
+        }
+    }
+
+    /// Emit a summary when the tree was large enough that detail was truncated.
+    pub fn finish(&self) {
+        let applied = self.applied.load(Ordering::Relaxed);
+        let skipped = self.skipped.load(Ordering::Relaxed);
+        if applied > DETAIL || skipped > DETAIL {
+            self.ctx.log(format!(
+                "{}: {} applied, {} skipped",
+                self.label, applied, skipped
+            ));
+        }
+    }
+}
+
+fn should_log_detail(n: usize) -> bool {
+    n <= DETAIL || n.is_multiple_of(EVERY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detail_logs_first_and_every_hundred() {
+        assert!(should_log_detail(1));
+        assert!(should_log_detail(5));
+        assert!(!should_log_detail(6));
+        assert!(should_log_detail(100));
+        assert!(!should_log_detail(101));
+        assert!(should_log_detail(200));
+    }
+}

--- a/src/engine/commands/symlink.rs
+++ b/src/engine/commands/symlink.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::utils::path::expand_path;
 
 use super::fs_ops::{self, FileOps};
+use super::progress_log::FileProgress;
 use super::tree;
 use super::CommandExecutor;
 
@@ -56,13 +57,17 @@ impl SymlinkCommand {
 
         let ops = fs_ops::select(self.args.sudo);
         let force = self.args.force;
-        tree::install_tree(
+        let progress = FileProgress::new(ctx, "symlink");
+        // Symlink create is metadata-cheap; keep sequential (Command bench).
+        tree::install_tree_with_pool(
             &src,
             &target,
             &self.args.ignore,
+            None,
             |dir| tree::ensure_real_dir(ops.as_ref(), dir, |msg| ctx.log(msg)),
-            |file, dest| symlink_one(ops.as_ref(), file, dest, force, ctx),
+            |file, dest| symlink_one(ops.as_ref(), file, dest, force, &progress),
         )?;
+        progress.finish();
         ops.flush()
     }
 
@@ -71,9 +76,11 @@ impl SymlinkCommand {
         let target = expand_path(&self.args.target, Some(&ctx.config_dir));
 
         let ops = fs_ops::select(self.args.sudo);
-        tree::uninstall_tree(&src, &target, &self.args.ignore, |dest| {
-            remove_link(ops.as_ref(), dest, ctx)
+        let progress = FileProgress::new(ctx, "symlink remove");
+        tree::uninstall_tree_with_pool(&src, &target, &self.args.ignore, None, |dest| {
+            remove_link(ops.as_ref(), dest, &progress)
         })?;
+        progress.finish();
         ops.flush()
     }
 }
@@ -85,42 +92,54 @@ fn symlink_one(
     src: &Path,
     dest: &Path,
     force: bool,
-    ctx: &CommandContext,
+    progress: &FileProgress<'_>,
 ) -> Result<()> {
     if dest.exists() || dest.symlink_metadata().is_ok() {
         if force {
-            ctx.log(format!("Removing existing: {}", dest.display()));
+            progress.note_apply(|| format!("Removing existing: {}", dest.display()));
             ops.remove_path(dest)?;
         } else {
-            ctx.log(format!("Skipping (already exists): {}", dest.display()));
+            progress.note_skip(|| format!("Skipping (already exists): {}", dest.display()));
             return Ok(());
         }
     }
 
     if let Some(parent) = dest.parent() {
-        tree::ensure_real_dir(ops, parent, |msg| ctx.log(msg))?;
+        // Parent was ensured by install_tree; only unwrap leftover dir symlinks.
+        tree::ensure_real_dir(ops, parent, |_| {})?;
     }
 
-    if let (Ok(src_canon), Ok(dest_canon)) =
-        (std::fs::canonicalize(src), std::fs::canonicalize(dest))
-    {
-        if src_canon == dest_canon {
-            return Err(Error::PathError(format!(
-                "Refusing to create self-symlink: {} -> {}",
-                src.display(),
-                dest.display()
-            )));
-        }
+    if would_self_symlink(src, dest) {
+        return Err(Error::PathError(format!(
+            "Refusing to create self-symlink: {} -> {}",
+            src.display(),
+            dest.display()
+        )));
     }
 
-    ctx.log(format!("Symlink: {} -> {}", src.display(), dest.display()));
+    progress.note_apply(|| format!("Symlink: {} -> {}", src.display(), dest.display()));
     ops.create_symlink(src, dest)
 }
 
+/// Cheap self-link check: path equality first; canonicalize only when both exist.
+fn would_self_symlink(src: &Path, dest: &Path) -> bool {
+    if src == dest {
+        return true;
+    }
+    // Dest usually does not exist yet — skip canonicalize syscalls in that case.
+    if dest.symlink_metadata().is_err() {
+        return false;
+    }
+    match (src.canonicalize(), dest.canonicalize()) {
+        (Ok(src_canon), Ok(dest_canon)) => src_canon == dest_canon,
+        _ => false,
+    }
+}
+
 /// Remove the symlink an install would have created at `dest`, if present.
-fn remove_link(ops: &dyn FileOps, dest: &Path, ctx: &CommandContext) -> Result<()> {
+fn remove_link(ops: &dyn FileOps, dest: &Path, progress: &FileProgress<'_>) -> Result<()> {
     if dest.symlink_metadata().is_ok() {
-        ctx.log(format!("Removing symlink: {}", dest.display()));
+        progress.note_apply(|| format!("Removing symlink: {}", dest.display()));
         ops.remove_symlink(dest)?;
     }
     Ok(())
@@ -161,9 +180,10 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let dest = dir.path().join("link");
         let (ctx, _rx) = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "symlink");
 
         let ops = RecordingFs::default();
-        symlink_one(&ops, &src, &dest, false, &ctx).unwrap();
+        symlink_one(&ops, &src, &dest, false, &progress).unwrap();
         assert_eq!(
             ops.calls(),
             vec![format!(
@@ -182,9 +202,10 @@ mod tests {
         let dest = dir.path().join("existing");
         std::fs::write(&dest, b"old").unwrap();
         let (ctx, _rx) = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "symlink");
 
         let ops = RecordingFs::default();
-        symlink_one(&ops, &src, &dest, false, &ctx).unwrap();
+        symlink_one(&ops, &src, &dest, false, &progress).unwrap();
         // Skipped: nothing touched.
         assert!(ops.calls().is_empty());
     }
@@ -197,9 +218,10 @@ mod tests {
         let dest = dir.path().join("existing");
         std::fs::write(&dest, b"old").unwrap();
         let (ctx, _rx) = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "symlink");
 
         let ops = RecordingFs::default();
-        symlink_one(&ops, &src, &dest, true, &ctx).unwrap();
+        symlink_one(&ops, &src, &dest, true, &progress).unwrap();
         assert_eq!(
             ops.calls(),
             vec![
@@ -210,13 +232,29 @@ mod tests {
     }
 
     #[test]
+    fn test_would_self_symlink_path_equality() {
+        let p = Path::new("/tmp/x");
+        assert!(would_self_symlink(p, p));
+    }
+
+    #[test]
+    fn test_would_self_symlink_skips_canonicalize_when_dest_missing() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("s");
+        std::fs::write(&src, b"x").unwrap();
+        let dest = dir.path().join("missing-link");
+        assert!(!would_self_symlink(&src, &dest));
+    }
+
+    #[test]
     fn test_remove_link_noop_when_absent() {
         let dir = tempdir().unwrap();
         let dest = dir.path().join("nope");
         let (ctx, _rx) = ctx_for(dir.path());
+        let progress = FileProgress::new(&ctx, "symlink remove");
 
         let ops = RecordingFs::default();
-        remove_link(&ops, &dest, &ctx).unwrap();
+        remove_link(&ops, &dest, &progress).unwrap();
         assert!(ops.calls().is_empty());
     }
 }

--- a/src/engine/commands/tree.rs
+++ b/src/engine/commands/tree.rs
@@ -9,13 +9,23 @@
 //! Destination resolution — the "is the target a file path or a directory to
 //! drop the file into" rule — lives here as one pure, table-tested function
 //! instead of being copy-pasted across four install/uninstall bodies.
+//!
+//! Directory installs create parents sequentially (WalkDir order), then apply
+//! files on the shared ConcurrencyGate Rayon pool (ADR-0004). Small trees and
+//! single-threaded pools stay sequential. No second concurrency knob.
 
 use std::path::{Path, PathBuf};
+
+use rayon::prelude::*;
+use rayon::ThreadPool;
 
 use crate::error::{Error, Result};
 use crate::utils::path::walk_relative;
 
 use super::fs_ops::FileOps;
+
+/// Below this many files, thread-pool apply costs more than it saves.
+const PARALLEL_FILE_THRESHOLD: usize = 32;
 
 /// Where a single source file lands, and which directory (if any) must exist
 /// before it is placed there.
@@ -49,46 +59,66 @@ pub fn resolve_single_file_dest(src: &Path, target: &Path) -> ResolvedDest {
     }
 }
 
-/// Apply an operation across a source onto `target`.
-///
-/// For a single file, resolves the destination, ensures the needed directory
-/// via `ensure_dir`, then calls `on_file(src_file, dest)`. For a directory,
-/// ensures `target` and walks the source (honoring `ignore`), ensuring
-/// directories via `ensure_dir` and calling `on_file` for each file. Because
-/// WalkDir yields a directory before its contents, every file's parent already
-/// exists by the time `on_file` runs.
-///
-/// Callers choose directory semantics: `copy` passes `|d| ops.mkdir_p(d)`;
-/// `symlink` passes [`ensure_real_dir`] so leftover directory symlinks cannot
-/// redirect leaf operations into the source tree.
+/// Apply an operation across a source onto `target` (sequential file apply).
 pub fn install_tree<F, E>(
     src: &Path,
     target: &Path,
     ignore: &[String],
-    mut ensure_dir: E,
-    mut on_file: F,
+    ensure_dir: E,
+    on_file: F,
 ) -> Result<()>
 where
     E: FnMut(&Path) -> Result<()>,
-    F: FnMut(&Path, &Path) -> Result<()>,
+    F: Fn(&Path, &Path) -> Result<()> + Sync,
+{
+    install_tree_with_pool(src, target, ignore, None, ensure_dir, on_file)
+}
+
+/// Like [`install_tree`], applying files on `pool` when it has more than one
+/// thread and the tree is large enough.
+///
+/// For a single file, resolves the destination, ensures the needed directory
+/// via `ensure_dir`, then calls `on_file(src_file, dest)`. For a directory,
+/// ensures `target` and walks the source (honoring `ignore`), ensuring
+/// directories via `ensure_dir`, then applies collected files. Because WalkDir
+/// yields a directory before its contents, every file's parent already exists
+/// by the time `on_file` runs.
+///
+/// Callers choose directory semantics: `copy` passes `|d| ops.mkdir_p(d)`;
+/// `symlink` passes [`ensure_real_dir`] so leftover directory symlinks cannot
+/// redirect leaf operations into the source tree.
+pub fn install_tree_with_pool<F, E>(
+    src: &Path,
+    target: &Path,
+    ignore: &[String],
+    pool: Option<&ThreadPool>,
+    mut ensure_dir: E,
+    on_file: F,
+) -> Result<()>
+where
+    E: FnMut(&Path) -> Result<()>,
+    F: Fn(&Path, &Path) -> Result<()> + Sync,
 {
     if src.is_file() {
         let resolved = resolve_single_file_dest(src, target);
         if let Some(dir) = &resolved.dir_to_create {
             ensure_dir(dir)?;
         }
-        on_file(src, &resolved.dest)?;
-    } else {
-        ensure_dir(target)?;
-        walk_relative(src, target, ignore, |entry, dest| {
-            if entry.file_type().is_dir() {
-                ensure_dir(dest)
-            } else {
-                on_file(entry.path(), dest)
-            }
-        })?;
+        return on_file(src, &resolved.dest);
     }
-    Ok(())
+
+    ensure_dir(target)?;
+    let mut files = Vec::new();
+    walk_relative(src, target, ignore, |entry, dest| {
+        if entry.file_type().is_dir() {
+            ensure_dir(dest)
+        } else {
+            files.push((entry.path().to_path_buf(), dest.to_path_buf()));
+            Ok(())
+        }
+    })?;
+
+    apply_files(pool, &files, &on_file)
 }
 
 /// Ensure `path` is a real directory — never leave a directory symlink in place.
@@ -113,37 +143,95 @@ pub fn ensure_real_dir(ops: &dyn FileOps, path: &Path, mut log: impl FnMut(Strin
     }
 }
 
-/// Undo an operation across a source onto `target`.
-///
-/// For a single file, resolves the destination and calls `on_dest(dest)`. For
-/// a directory, walks the source and calls `on_dest` for each file's mapped
-/// destination. Directory destinations are left in place — only the files an
-/// install would have created are targeted.
-pub fn uninstall_tree<F>(src: &Path, target: &Path, ignore: &[String], mut on_dest: F) -> Result<()>
+/// Undo an operation across a source onto `target` (sequential removes).
+pub fn uninstall_tree<F>(src: &Path, target: &Path, ignore: &[String], on_dest: F) -> Result<()>
 where
-    F: FnMut(&Path) -> Result<()>,
+    F: Fn(&Path) -> Result<()> + Sync,
+{
+    uninstall_tree_with_pool(src, target, ignore, None, on_dest)
+}
+
+/// Like [`uninstall_tree`], removing on `pool` when parallel apply is worth it.
+pub fn uninstall_tree_with_pool<F>(
+    src: &Path,
+    target: &Path,
+    ignore: &[String],
+    pool: Option<&ThreadPool>,
+    on_dest: F,
+) -> Result<()>
+where
+    F: Fn(&Path) -> Result<()> + Sync,
 {
     if src.is_file() {
         let dest = resolve_single_file_dest(src, target).dest;
-        on_dest(&dest)?;
-    } else {
-        walk_relative(src, target, ignore, |entry, dest| {
-            if entry.file_type().is_file() {
-                on_dest(dest)
-            } else {
-                Ok(())
-            }
-        })?;
+        return on_dest(&dest);
     }
-    Ok(())
+
+    let mut dests = Vec::new();
+    walk_relative(src, target, ignore, |entry, dest| {
+        if entry.file_type().is_file() {
+            dests.push(dest.to_path_buf());
+        }
+        Ok(())
+    })?;
+
+    apply_dests(pool, &dests, &on_dest)
+}
+
+fn apply_files<F>(pool: Option<&ThreadPool>, files: &[(PathBuf, PathBuf)], on_file: &F) -> Result<()>
+where
+    F: Fn(&Path, &Path) -> Result<()> + Sync,
+{
+    if !should_parallelize(pool, files.len()) {
+        for (src, dest) in files {
+            on_file(src, dest)?;
+        }
+        return Ok(());
+    }
+
+    let pool = pool.expect("should_parallelize implies pool");
+    pool.install(|| {
+        files
+            .par_iter()
+            .try_for_each(|(src, dest)| on_file(src, dest))
+    })
+}
+
+fn apply_dests<F>(pool: Option<&ThreadPool>, dests: &[PathBuf], on_dest: &F) -> Result<()>
+where
+    F: Fn(&Path) -> Result<()> + Sync,
+{
+    if !should_parallelize(pool, dests.len()) {
+        for dest in dests {
+            on_dest(dest)?;
+        }
+        return Ok(());
+    }
+
+    let pool = pool.expect("should_parallelize implies pool");
+    pool.install(|| dests.par_iter().try_for_each(|dest| on_dest(dest)))
+}
+
+fn should_parallelize(pool: Option<&ThreadPool>, n: usize) -> bool {
+    match pool {
+        Some(pool) => pool.current_num_threads() > 1 && n >= PARALLEL_FILE_THRESHOLD,
+        None => false,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::engine::commands::fs_ops::{DirectFs, RecordingFs};
-    use std::cell::RefCell;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    fn test_pool(threads: usize) -> ThreadPool {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap()
+    }
 
     #[test]
     fn test_resolve_dest_target_with_extension_is_file_path() {
@@ -178,7 +266,7 @@ mod tests {
         let target = dir.path().join("out/file.txt");
 
         let ops = RecordingFs::default();
-        let applied = RefCell::new(Vec::new());
+        let applied = Mutex::new(Vec::new());
         install_tree(
             &src,
             &target,
@@ -186,7 +274,8 @@ mod tests {
             |d| ops.mkdir_p(d),
             |s, d| {
                 applied
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .push(format!("{} -> {}", s.display(), d.display()));
                 Ok(())
             },
@@ -199,7 +288,7 @@ mod tests {
             vec![format!("mkdir_p {}", dir.path().join("out").display())]
         );
         assert_eq!(
-            applied.into_inner(),
+            applied.into_inner().unwrap(),
             vec![format!("{} -> {}", src.display(), target.display())]
         );
     }
@@ -214,7 +303,7 @@ mod tests {
         let target = dir.path().join("dst");
 
         let ops = RecordingFs::default();
-        let files = RefCell::new(Vec::new());
+        let files = Mutex::new(Vec::new());
         install_tree(
             &src,
             &target,
@@ -222,14 +311,15 @@ mod tests {
             |d| ops.mkdir_p(d),
             |s, _d| {
                 files
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .push(s.file_name().unwrap().to_string_lossy().into_owned());
                 Ok(())
             },
         )
         .unwrap();
 
-        let mut applied = files.into_inner();
+        let mut applied = files.into_inner().unwrap();
         applied.sort();
         assert_eq!(applied, vec!["a.txt", "b.txt"]);
         // Directories were created via ops (target + sub at least).
@@ -248,7 +338,7 @@ mod tests {
         let target = dir.path().join("dst");
 
         let ops = RecordingFs::default();
-        let files = RefCell::new(Vec::new());
+        let files = Mutex::new(Vec::new());
         install_tree(
             &src,
             &target,
@@ -256,14 +346,48 @@ mod tests {
             |d| ops.mkdir_p(d),
             |s, _d| {
                 files
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .push(s.file_name().unwrap().to_string_lossy().into_owned());
                 Ok(())
             },
         )
         .unwrap();
 
-        assert_eq!(files.into_inner(), vec!["keep.txt"]);
+        assert_eq!(files.into_inner().unwrap(), vec!["keep.txt"]);
+    }
+
+    #[test]
+    fn test_install_tree_parallel_applies_all_files() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        for i in 0..64 {
+            std::fs::write(src.join(format!("f{i}.txt")), b"x").unwrap();
+        }
+        let target = dir.path().join("dst");
+        let pool = test_pool(4);
+
+        let applied = Mutex::new(0usize);
+        install_tree_with_pool(
+            &src,
+            &target,
+            &[],
+            Some(&pool),
+            |d| {
+                std::fs::create_dir_all(d)?;
+                Ok(())
+            },
+            |_s, d| {
+                std::fs::write(d, b"y")?;
+                *applied.lock().unwrap() += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(*applied.lock().unwrap(), 64);
+        assert_eq!(std::fs::read(target.join("f0.txt")).unwrap(), b"y");
     }
 
     #[test]
@@ -273,14 +397,17 @@ mod tests {
         std::fs::write(&src, b"data").unwrap();
         let target = dir.path().join("out/file.txt");
 
-        let removed = RefCell::new(Vec::new());
+        let removed = Mutex::new(Vec::new());
         uninstall_tree(&src, &target, &[], |d| {
-            removed.borrow_mut().push(d.display().to_string());
+            removed.lock().unwrap().push(d.display().to_string());
             Ok(())
         })
         .unwrap();
 
-        assert_eq!(removed.into_inner(), vec![target.display().to_string()]);
+        assert_eq!(
+            removed.into_inner().unwrap(),
+            vec![target.display().to_string()]
+        );
     }
 
     #[test]
@@ -292,16 +419,17 @@ mod tests {
         std::fs::write(src.join("sub/b.txt"), b"b").unwrap();
         let target = dir.path().join("dst");
 
-        let removed = RefCell::new(Vec::new());
+        let removed = Mutex::new(Vec::new());
         uninstall_tree(&src, &target, &[], |d| {
             removed
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .push(d.file_name().unwrap().to_string_lossy().into_owned());
             Ok(())
         })
         .unwrap();
 
-        let mut got = removed.into_inner();
+        let mut got = removed.into_inner().unwrap();
         got.sort();
         assert_eq!(got, vec!["a.txt", "b.txt"]);
     }
@@ -316,14 +444,15 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         let ops = DirectFs;
-        let logs = RefCell::new(Vec::new());
-        ensure_real_dir(&ops, &link, |msg| logs.borrow_mut().push(msg)).unwrap();
+        let logs = Mutex::new(Vec::new());
+        ensure_real_dir(&ops, &link, |msg| logs.lock().unwrap().push(msg)).unwrap();
 
         let meta = link.symlink_metadata().unwrap();
         assert!(meta.is_dir() && !meta.file_type().is_symlink());
         assert!(real.exists());
         assert!(logs
             .into_inner()
+            .unwrap()
             .iter()
             .any(|m| m.contains("Unwrapping directory symlink")));
     }

--- a/src/engine/concurrency.rs
+++ b/src/engine/concurrency.rs
@@ -1,9 +1,11 @@
 //! Concurrency gate — global cap on in-flight Task / Command executor work.
 //!
 //! See ADR-0003. Does not order Tasks by dependency (that is the Task graph).
+//! Also owns the shared Rayon pool used for in-tree file apply (ADR-0004).
 
 use std::sync::Arc;
 
+use rayon::ThreadPool;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Shared limit on concurrent Task and Command executor work.
@@ -12,16 +14,25 @@ pub struct ConcurrencyGate {
     sem: Arc<Semaphore>,
     /// Configured permit count (for tests / diagnostics).
     pub limit: usize,
+    /// Shared FS apply pool — sized by `limit`, shared across Command entries.
+    pool: Arc<ThreadPool>,
 }
 
 impl ConcurrencyGate {
     /// Build a gate from `AppConfig.num_threads` (None → CPUs − 1, at least 1).
     pub fn from_num_threads(num_threads: Option<usize>) -> Self {
         let limit = resolve_limit(num_threads);
+        let pool = build_fs_pool(limit);
         Self {
             sem: Arc::new(Semaphore::new(limit)),
             limit,
+            pool: Arc::new(pool),
         }
+    }
+
+    /// Shared Rayon pool for in-tree DirectFs file apply.
+    pub fn pool(&self) -> &ThreadPool {
+        &self.pool
     }
 
     /// Acquire one permit; held for the lifetime of the returned guard.
@@ -32,6 +43,14 @@ impl ConcurrencyGate {
             .await
             .expect("ConcurrencyGate semaphore is never closed")
     }
+}
+
+fn build_fs_pool(limit: usize) -> ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(limit)
+        .thread_name(|i| format!("machine-setup-fs-{i}"))
+        .build()
+        .expect("ConcurrencyGate Rayon pool")
 }
 
 /// Resolve `num_threads` to a positive permit count.


### PR DESCRIPTION
## Summary
- Parallelize DirectFs copy/uninstall file apply on a shared Rayon pool owned by the Concurrency gate (sized by `num_threads`), so sibling tasks do not oversubscribe
- Trim hot-path costs: skip redundant `create_dir_all`, coalesce tree progress logs, cheap self-symlink checks; keep symlink sequential (metadata-cheap)
- Update ADR-0004 / Command bench; measured ~35–59% wins on tree install and runner smoke

## Test plan
- [x] `cargo test --lib`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo bench --bench command_bench -- --noplot`